### PR TITLE
Add Stripe webhook for payment events

### DIFF
--- a/apps/api/src/auth/jwt.guard.ts
+++ b/apps/api/src/auth/jwt.guard.ts
@@ -22,8 +22,8 @@ export class JwtAuthGuard implements CanActivate {
 	async canActivate(context: ExecutionContext): Promise<boolean> {
 		const req = context.switchToHttp().getRequest<Request>()
 
-		// Skip authentication for health endpoints
-		if (req.url === "/health" || req.url === "/health/db") {
+		// Skip authentication for public endpoints
+		if (req.url === "/health" || req.url === "/health/db" || req.url === "/stripe/webhook") {
 			return true
 		}
 

--- a/apps/api/src/golfgenius/api-client.ts
+++ b/apps/api/src/golfgenius/api-client.ts
@@ -268,7 +268,11 @@ export class ApiClient {
 		return GgMemberSchema.parse(mem)
 	}
 
-	async updateMemberRegistration(eventId: string, memberId: string, member: GgMemberSyncData): Promise<GgMember> {
+	async updateMemberRegistration(
+		eventId: string,
+		memberId: string,
+		member: GgMemberSyncData,
+	): Promise<GgMember> {
 		const endpoint = `/api_v2/events/${eventId}/members/${memberId}`
 		const mem = await this.request("put", endpoint, { json: member })
 		return GgMemberSchema.parse(mem)

--- a/apps/api/src/golfgenius/api-data/course.ts
+++ b/apps/api/src/golfgenius/api-data/course.ts
@@ -5,38 +5,35 @@ import { z } from "zod"
  * Contains arrays of par, yardage, and handicap for each hole
  * Values are nullable for unused holes (e.g., holes 10-18 in 9-hole courses)
  */
-export const GgHoleDataSchema = z
-	.object({
-		par: z.array(z.number().nullable()),
-		yardage: z.array(z.number().nullable()),
-		handicap: z.array(z.number().nullable()),
-	})
+export const GgHoleDataSchema = z.object({
+	par: z.array(z.number().nullable()),
+	yardage: z.array(z.number().nullable()),
+	handicap: z.array(z.number().nullable()),
+})
 
 /**
  * Schema for Golf Genius tee data
  * Validates id, name, abbreviation, and hole_data fields
  * Uses catchall to allow additional unvalidated properties
  */
-export const GgTeeSchema = z
-	.object({
-		id: z.string(),
-		name: z.string(),
-		abbreviation: z.string(),
-		hole_data: GgHoleDataSchema,
-	})
+export const GgTeeSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	abbreviation: z.string(),
+	hole_data: GgHoleDataSchema,
+})
 
 /**
  * Schema for Golf Genius course data
  * Validates id, name, abbreviation, and tees array
  * Uses catchall to allow additional unvalidated properties
  */
-export const GgCourseSchema = z
-	.object({
-		id: z.string(),
-		name: z.string(),
-		abbreviation: z.string(),
-		tees: z.array(GgTeeSchema),
-	})
+export const GgCourseSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	abbreviation: z.string(),
+	tees: z.array(GgTeeSchema),
+})
 
 /**
  * Schema for Golf Genius courses API response

--- a/apps/api/src/golfgenius/api-data/event.ts
+++ b/apps/api/src/golfgenius/api-data/event.ts
@@ -22,17 +22,16 @@ import { z } from "zod"
 
 // Schema for a single event object
 // Validates only the specified fields; all other properties are allowed but not validated
-export const GgEventSchema = z
-	.object({
-		id: z.string(),
-		ggid: z.string(),
-		name: z.string(),
-		start_date: z.string(),
-		end_date: z.string(),
-		type: z.string(),
-		website: z.string().optional(),
-		description: z.string().optional(),
-	})
+export const GgEventSchema = z.object({
+	id: z.string(),
+	ggid: z.string(),
+	name: z.string(),
+	start_date: z.string(),
+	end_date: z.string(),
+	type: z.string(),
+	website: z.string().optional(),
+	description: z.string().optional(),
+})
 
 // Schema for the wrapped event object (as returned by the API)
 export const GgEventWrapperSchema = z.object({

--- a/apps/api/src/golfgenius/api-data/member.ts
+++ b/apps/api/src/golfgenius/api-data/member.ts
@@ -5,31 +5,29 @@ import { z } from "zod"
  * Contains handicap network information and index values
  * Uses catchall to allow additional unvalidated properties
  */
-export const GgHandicapSchema = z
-	.object({
-		handicap_network_id: z.string(),
-		handicap_index: z.string(),
-		nine_hole_handicap_index: z.string(),
-	})
+export const GgHandicapSchema = z.object({
+	handicap_network_id: z.string(),
+	handicap_index: z.string(),
+	nine_hole_handicap_index: z.string(),
+})
 
 /**
  * Schema for Golf Genius member data
  * Contains participant/registration information for an event
  * Uses catchall to allow additional unvalidated properties
  */
-export const GgMemberSchema = z
-	.object({
-		id: z.string(),
-		name: z.string(),
-		email: z.string(),
-		last_name: z.string(),
-		first_name: z.string(),
-		event_id: z.string(),
-		member_card_id: z.string(),
-		external_id: z.string().nullable(),
-		handicap: GgHandicapSchema,
-		custom_fields: z.record(z.string(), z.unknown()), // Catchall collection for dynamic custom fields
-	})
+export const GgMemberSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	email: z.string(),
+	last_name: z.string(),
+	first_name: z.string(),
+	event_id: z.string(),
+	member_card_id: z.string(),
+	external_id: z.string().nullable(),
+	handicap: GgHandicapSchema,
+	custom_fields: z.record(z.string(), z.unknown()), // Catchall collection for dynamic custom fields
+})
 
 /**
  * Schema for Golf Genius member API response wrapper

--- a/apps/api/src/golfgenius/api-data/round.ts
+++ b/apps/api/src/golfgenius/api-data/round.ts
@@ -21,15 +21,14 @@ import { z } from "zod"
 
 // Schema for a single round object
 // Validates only the specified fields; all other properties are allowed but not validated
-export const GgRoundSchema = z
-	.object({
-		id: z.string(),
-		index: z.number(),
-		event_id: z.string(),
-		name: z.string(),
-		date: z.string(),
-		status: z.string(),
-	})
+export const GgRoundSchema = z.object({
+	id: z.string(),
+	index: z.number(),
+	event_id: z.string(),
+	name: z.string(),
+	date: z.string(),
+	status: z.string(),
+})
 
 // Schema for the wrapped round object (as returned by the API)
 export const GgRoundWrapperSchema = z.object({

--- a/apps/api/src/golfgenius/api-data/teesheet.ts
+++ b/apps/api/src/golfgenius/api-data/teesheet.ts
@@ -3,50 +3,47 @@ import { z } from "zod"
 import { GgHoleDataSchema } from "./course"
 
 // Tee schema for teesheet (includes course_id)
-export const GgTeesheetTeeSchema = z
-	.object({
-		name: z.string(),
-		abbreviation: z.string(),
-		hole_data: GgHoleDataSchema,
-		id: z.string(),
-		course_id: z.string(),
-	})
+export const GgTeesheetTeeSchema = z.object({
+	name: z.string(),
+	abbreviation: z.string(),
+	hole_data: GgHoleDataSchema,
+	id: z.string(),
+	course_id: z.string(),
+})
 
 export type GgTeesheetTee = z.infer<typeof GgTeesheetTeeSchema>
 
 // Player schema with scoring and handicap information
-export const GgPlayerSchema = z
-	.object({
-		name: z.string(),
-		last_name: z.string(),
-		first_name: z.string(),
-		position: z.number(),
-		member_card_id: z.string(),
-		player_roster_id: z.string(),
-		handicap_network_id: z.string(),
-		player_round_id: z.string(),
-		external_id: z.string().nullable(),
-		group_number: z.number(),
-		team_name: z.string(),
-		handicap_index: z.string(),
-		course_handicap: z.string(),
-		score_array: z.array(z.number().nullable()),
-		handicap_dots_by_hole: z.array(z.number()),
-		tee: GgTeesheetTeeSchema,
-	})
+export const GgPlayerSchema = z.object({
+	name: z.string(),
+	last_name: z.string(),
+	first_name: z.string(),
+	position: z.number(),
+	member_card_id: z.string(),
+	player_roster_id: z.string(),
+	handicap_network_id: z.string(),
+	player_round_id: z.string(),
+	external_id: z.string().nullable(),
+	group_number: z.number(),
+	team_name: z.string(),
+	handicap_index: z.string(),
+	course_handicap: z.string(),
+	score_array: z.array(z.number().nullable()),
+	handicap_dots_by_hole: z.array(z.number()),
+	tee: GgTeesheetTeeSchema,
+})
 
 export type GgPlayer = z.infer<typeof GgPlayerSchema>
 
 // Pairing group schema with tee time and players
-export const GgPairingGroupSchema = z
-	.object({
-		id: z.string(),
-		hole: z.number(),
-		tee_time: z.string(),
-		date: z.string(),
-		foursome_ggid: z.string(),
-		players: z.array(GgPlayerSchema),
-	})
+export const GgPairingGroupSchema = z.object({
+	id: z.string(),
+	hole: z.number(),
+	tee_time: z.string(),
+	date: z.string(),
+	foursome_ggid: z.string(),
+	players: z.array(GgPlayerSchema),
+})
 
 export type GgPairingGroup = z.infer<typeof GgPairingGroupSchema>
 

--- a/apps/api/src/golfgenius/api-data/tournament.ts
+++ b/apps/api/src/golfgenius/api-data/tournament.ts
@@ -24,16 +24,15 @@ import { z } from "zod"
 
 // Schema for a single tournament object
 // Validates only the specified fields; all other properties are allowed but not validated
-export const GgTournamentSchema = z
-	.object({
-		id: z.string(),
-		name: z.string(),
-		score_format: z.string(),
-		handicap_format: z.string(),
-		score_scope: z.string(),
-		result_scope: z.string(),
-		score_aggregation: z.string(),
-	})
+export const GgTournamentSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	score_format: z.string(),
+	handicap_format: z.string(),
+	score_scope: z.string(),
+	result_scope: z.string(),
+	score_aggregation: z.string(),
+})
 
 // Schema for the wrapped tournament object (as returned by the API)
 // Note: The API wraps tournaments in an "event" property

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -25,6 +25,7 @@ async function bootstrap() {
 	}
 	const app = await NestFactory.create(AppModule, {
 		logger: enabledLevels.length > 0 ? enabledLevels : false,
+		rawBody: true,
 	})
 	const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3001
 	const webOrigin = process.env.WEB_ORIGIN || "http://localhost:3000"

--- a/apps/api/src/registration/registration.module.ts
+++ b/apps/api/src/registration/registration.module.ts
@@ -1,13 +1,14 @@
-import { Module } from "@nestjs/common"
+import { forwardRef, Module } from "@nestjs/common"
 
 import { CoursesModule } from "../courses/courses.module"
 import { DatabaseModule } from "../database/database.module"
 import { EventsModule } from "../events/events.module"
+import { StripeModule } from "../stripe/stripe.module"
 import { RegistrationRepository, RegistrationService } from "./"
 import { RegistrationController } from "./registration.controller"
-import { StripeModule } from "../stripe/stripe.module"
+
 @Module({
-	imports: [CoursesModule, DatabaseModule, EventsModule, StripeModule],
+	imports: [CoursesModule, DatabaseModule, EventsModule, forwardRef(() => StripeModule)],
 	controllers: [RegistrationController],
 	providers: [RegistrationRepository, RegistrationService],
 	exports: [RegistrationRepository, RegistrationService],

--- a/apps/api/src/stripe/config/stripe.validation.ts
+++ b/apps/api/src/stripe/config/stripe.validation.ts
@@ -1,0 +1,7 @@
+import * as Joi from "joi"
+
+export const stripeValidationSchema = Joi.object({
+	STRIPE_SECRET_KEY: Joi.string().required(),
+	STRIPE_WEBHOOK_SECRET: Joi.string().required(),
+	STRIPE_API_VERSION: Joi.string().default("2025-11-25.clover"),
+})

--- a/apps/api/src/stripe/index.ts
+++ b/apps/api/src/stripe/index.ts
@@ -1,2 +1,3 @@
 export * from "./stripe.module"
 export * from "./stripe.service"
+export * from "./stripe-webhook.service"

--- a/apps/api/src/stripe/stripe-webhook.service.ts
+++ b/apps/api/src/stripe/stripe-webhook.service.ts
@@ -1,0 +1,228 @@
+import { Injectable, Logger } from "@nestjs/common"
+import { eq, inArray } from "drizzle-orm"
+import Stripe from "stripe"
+
+import {
+	DjangoUser,
+	Payment,
+	RegistrationStatusChoices,
+	ValidatedPayment,
+	ValidatedRegistrationFee,
+} from "@repo/domain/types"
+
+import {
+	authUser,
+	DrizzleService,
+	payment,
+	registrationFee,
+	registrationSlot,
+	toDbString,
+} from "../database"
+import { EventsService } from "../events"
+import { MailService } from "../mail"
+import {
+	RegistrationRepository,
+	RegistrationService,
+	toRegistrationFeeWithEventFee,
+} from "../registration"
+
+@Injectable()
+export class StripeWebhookService {
+	private readonly logger = new Logger(StripeWebhookService.name)
+
+	constructor(
+		private drizzle: DrizzleService,
+		private registrationRepository: RegistrationRepository,
+		private registrationService: RegistrationService,
+		private eventsService: EventsService,
+		private mailService: MailService,
+	) {}
+
+	async handlePaymentIntentSucceeded(paymentIntent: Stripe.PaymentIntent): Promise<void> {
+		const paymentIntentId = paymentIntent.id
+		this.logger.log(`Processing payment_intent.succeeded: ${paymentIntentId}`)
+
+		// Find payment by paymentCode (stores "pi_*" before confirmation)
+		const [paymentRecord] = await this.drizzle.db
+			.select()
+			.from(payment)
+			.where(eq(payment.paymentCode, paymentIntentId))
+			.limit(1)
+
+		if (!paymentRecord) {
+			this.logger.warn(`No payment found for paymentIntent ${paymentIntentId}`)
+			return
+		}
+
+		// Already confirmed? Skip (idempotency)
+		if (paymentRecord.confirmed) {
+			this.logger.log(`Payment ${paymentRecord.id} already confirmed, skipping`)
+			return
+		}
+
+		const now = toDbString(new Date())
+
+		await this.drizzle.db.transaction(async (tx) => {
+			// 1. Update payment: confirmed=1, confirmDate
+			await tx
+				.update(payment)
+				.set({
+					confirmed: 1,
+					confirmDate: now,
+					paymentDate: now,
+				})
+				.where(eq(payment.id, paymentRecord.id))
+
+			// 2. Get all registrationFees for this payment
+			const fees = await tx
+				.select()
+				.from(registrationFee)
+				.where(eq(registrationFee.paymentId, paymentRecord.id))
+
+			if (fees.length === 0) {
+				this.logger.warn(`No registration fees found for payment ${paymentRecord.id}`)
+				return
+			}
+
+			// 3. Update registrationFee: isPaid=1
+			const feeIds = fees.map((f) => f.id)
+			await tx.update(registrationFee).set({ isPaid: 1 }).where(inArray(registrationFee.id, feeIds))
+
+			// 4. Get unique slot IDs and update status X -> R
+			const slotIds = [
+				...new Set(fees.map((f) => f.registrationSlotId).filter(Boolean)),
+			] as number[]
+			if (slotIds.length > 0) {
+				await tx
+					.update(registrationSlot)
+					.set({ status: RegistrationStatusChoices.RESERVED })
+					.where(inArray(registrationSlot.id, slotIds))
+			}
+		})
+
+		// 5. Send confirmation email (outside transaction)
+		await this.sendConfirmationEmail(paymentRecord.id, paymentRecord.eventId, paymentRecord.userId)
+	}
+
+	handlePaymentIntentFailed(paymentIntent: Stripe.PaymentIntent): void {
+		this.logger.log(`Payment failed: ${paymentIntent.id}`)
+		// TODO: Notify admin or update payment status
+	}
+
+	handleRefundCreated(refundEvent: Stripe.Refund): void {
+		this.logger.log(`Refund created: ${refundEvent.id}`)
+		// TODO: Update refund record status
+	}
+
+	handleRefundUpdated(refundEvent: Stripe.Refund): void {
+		this.logger.log(`Refund updated: ${refundEvent.id}, status: ${String(refundEvent.status)}`)
+		// TODO: Update confirmed status based on refund.status
+	}
+
+	private async sendConfirmationEmail(
+		paymentId: number,
+		eventId: number,
+		userId: number,
+	): Promise<void> {
+		try {
+			// Get user from authUser table
+			const [userRow] = await this.drizzle.db
+				.select()
+				.from(authUser)
+				.where(eq(authUser.id, userId))
+				.limit(1)
+
+			if (!userRow) {
+				this.logger.warn(`User ${userId} not found for confirmation email`)
+				return
+			}
+
+			const user: DjangoUser = {
+				id: userRow.id,
+				email: userRow.email,
+				firstName: userRow.firstName,
+				lastName: userRow.lastName,
+				isActive: Boolean(userRow.isActive),
+				isStaff: Boolean(userRow.isStaff),
+				ghin: null,
+				birthDate: null,
+			}
+
+			// Get event
+			const event = await this.eventsService.getValidatedClubEventById(eventId, false)
+
+			// Get fees with slot info to find the registration
+			const fees = await this.registrationRepository.findRegistrationFeesByPayment(paymentId)
+			if (fees.length === 0) {
+				this.logger.warn(`No fees found for payment ${paymentId}`)
+				return
+			}
+
+			const firstFee = fees[0]
+			const slotId = firstFee.registrationSlotId
+			const slot = await this.registrationRepository.findRegistrationSlotById(slotId)
+
+			if (!slot.playerId) {
+				this.logger.warn(`Slot ${slotId} has no player`)
+				return
+			}
+
+			// Get validated registration
+			const registration = await this.registrationService.findGroup(eventId, slot.playerId)
+
+			// Build validated payment with fee details
+			const paymentWithDetails =
+				await this.registrationRepository.findPaymentWithDetailsById(paymentId)
+			if (!paymentWithDetails) {
+				this.logger.warn(`Payment ${paymentId} not found with details`)
+				return
+			}
+
+			// Get fees with eventFee data for ValidatedPayment
+			const slotIds = fees.map((f) => f.registrationSlotId)
+			const feesWithEventFee =
+				await this.registrationRepository.findFeesWithEventFeeAndFeeType(slotIds)
+
+			const validatedFees: ValidatedRegistrationFee[] = feesWithEventFee
+				.filter((f) => f.eventFee && f.feeType)
+				.map(
+					(f) =>
+						toRegistrationFeeWithEventFee(
+							f as {
+								fee: typeof f.fee
+								eventFee: NonNullable<typeof f.eventFee>
+								feeType: NonNullable<typeof f.feeType>
+							},
+						) as ValidatedRegistrationFee,
+				)
+
+			const validatedPayment: ValidatedPayment = {
+				id: paymentWithDetails.payment.id,
+				paymentCode: paymentWithDetails.payment.paymentCode,
+				paymentKey: paymentWithDetails.payment.paymentKey ?? null,
+				notificationType: paymentWithDetails.payment
+					.notificationType as Payment["notificationType"],
+				confirmed: Boolean(paymentWithDetails.payment.confirmed),
+				eventId: paymentWithDetails.payment.eventId,
+				userId: paymentWithDetails.payment.userId,
+				paymentAmount: parseFloat(paymentWithDetails.payment.paymentAmount),
+				transactionFee: parseFloat(paymentWithDetails.payment.transactionFee),
+				paymentDate: paymentWithDetails.payment.paymentDate ?? new Date().toISOString(),
+				confirmDate: paymentWithDetails.payment.confirmDate ?? null,
+				paymentDetails: validatedFees,
+			}
+
+			await this.mailService.sendRegistrationConfirmation(
+				user,
+				event,
+				registration,
+				validatedPayment,
+			)
+			this.logger.log(`Confirmation email sent for payment ${paymentId}`)
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			this.logger.error(`Failed to send confirmation email: ${message}`)
+			// Don't throw - email failure shouldn't fail the webhook
+		}
+	}
+}

--- a/apps/api/src/stripe/stripe.controller.ts
+++ b/apps/api/src/stripe/stripe.controller.ts
@@ -1,0 +1,65 @@
+import {
+	Controller,
+	Post,
+	Headers,
+	RawBody,
+	HttpCode,
+	HttpStatus,
+	BadRequestException,
+	Logger,
+} from "@nestjs/common"
+import Stripe from "stripe"
+
+import { StripeService } from "./stripe.service"
+import { StripeWebhookService } from "./stripe-webhook.service"
+
+@Controller("stripe")
+export class StripeController {
+	private readonly logger = new Logger(StripeController.name)
+
+	constructor(
+		private readonly stripeService: StripeService,
+		private readonly webhookService: StripeWebhookService,
+	) {}
+
+	@Post("webhook")
+	@HttpCode(HttpStatus.OK)
+	async handleWebhook(
+		@Headers("stripe-signature") signature: string,
+		@RawBody() rawBody: Buffer,
+	): Promise<{ received: boolean }> {
+		if (!signature) {
+			throw new BadRequestException("Missing stripe-signature header")
+		}
+
+		let event: Stripe.Event
+		try {
+			event = this.stripeService.constructWebhookEvent(rawBody, signature)
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err)
+			this.logger.error(`Webhook signature verification failed: ${message}`)
+			throw new BadRequestException("Invalid webhook signature")
+		}
+
+		this.logger.log(`Received Stripe event: ${event.type}`)
+
+		switch (event.type) {
+			case "payment_intent.succeeded":
+				await this.webhookService.handlePaymentIntentSucceeded(event.data.object)
+				break
+			case "payment_intent.payment_failed":
+				this.webhookService.handlePaymentIntentFailed(event.data.object)
+				break
+			case "refund.created":
+				this.webhookService.handleRefundCreated(event.data.object)
+				break
+			case "refund.updated":
+				this.webhookService.handleRefundUpdated(event.data.object)
+				break
+			default:
+				this.logger.log(`Unhandled event type: ${event.type}`)
+		}
+
+		return { received: true }
+	}
+}

--- a/apps/api/src/stripe/stripe.module.ts
+++ b/apps/api/src/stripe/stripe.module.ts
@@ -1,11 +1,28 @@
-import { Module } from "@nestjs/common"
+import { forwardRef, Module } from "@nestjs/common"
 import { ConfigModule } from "@nestjs/config"
 
+import { DatabaseModule } from "../database/database.module"
+import { EventsModule } from "../events/events.module"
+import { MailModule } from "../mail/mail.module"
+import { RegistrationModule } from "../registration/registration.module"
+import { stripeValidationSchema } from "./config/stripe.validation"
+import { StripeController } from "./stripe.controller"
 import { StripeService } from "./stripe.service"
+import { StripeWebhookService } from "./stripe-webhook.service"
 
 @Module({
-	imports: [ConfigModule],
-	providers: [StripeService],
+	imports: [
+		ConfigModule.forRoot({
+			validationSchema: stripeValidationSchema,
+			validationOptions: { allowUnknown: true },
+		}),
+		DatabaseModule,
+		EventsModule,
+		MailModule,
+		forwardRef(() => RegistrationModule),
+	],
+	controllers: [StripeController],
+	providers: [StripeService, StripeWebhookService],
 	exports: [StripeService],
 })
 export class StripeModule {}

--- a/apps/api/src/stripe/stripe.service.ts
+++ b/apps/api/src/stripe/stripe.service.ts
@@ -5,6 +5,7 @@ import Stripe from "stripe"
 @Injectable()
 export class StripeService {
 	private stripe: Stripe
+	private webhookSecret: string
 
 	constructor(private configService: ConfigService) {
 		const secretKey = this.configService.get<string>("STRIPE_SECRET_KEY")
@@ -16,6 +17,11 @@ export class StripeService {
 			"2024-12-18.acacia",
 		) as Stripe.LatestApiVersion
 		this.stripe = new Stripe(secretKey, { apiVersion })
+		this.webhookSecret = this.configService.getOrThrow<string>("STRIPE_WEBHOOK_SECRET")
+	}
+
+	constructWebhookEvent(payload: Buffer, signature: string): Stripe.Event {
+		return this.stripe.webhooks.constructEvent(payload, signature, this.webhookSecret)
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Add POST `/stripe/webhook` endpoint with signature verification
- Implement `payment_intent.succeeded` handler: confirm payment, mark fees paid, transition slots X→R, send email
- Create placeholders for `payment_failed`, `refund.created`, `refund.updated`
- Enable rawBody in main.ts for webhook signature verification
- Skip auth for webhook endpoint
- Requires `STRIPE_WEBHOOK_SECRET` env var

## Test plan
- [ ] Configure Stripe webhook in dashboard pointing to `/stripe/webhook`
- [ ] Add `STRIPE_WEBHOOK_SECRET` to environment
- [ ] Test payment success flow via Stripe test mode
- [ ] Verify payment record updated (confirmed, confirmDate)
- [ ] Verify registration fees marked isPaid
- [ ] Verify slots transitioned from X to R
- [ ] Verify confirmation email sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Stripe webhook support for payment event processing.
  * Automatic confirmation emails triggered upon successful payment.
  * Registration slots now automatically marked as reserved following successful payment confirmation.
  * Payment failure and refund event tracking now active.

* **Chores**
  * Code formatting optimizations applied to internal schema definitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->