### PR TITLE
Add Stripe webhook for payment and refund events

### DIFF
--- a/apps/api/src/mail/mail.service.ts
+++ b/apps/api/src/mail/mail.service.ts
@@ -19,7 +19,7 @@ import * as nodemailer from "nodemailer"
 import mailgunTransport from "nodemailer-mailgun-transport"
 import type { ReactElement } from "react"
 
-import { RegistrationConfirmationEmail, WelcomeEmail } from "./templates"
+import { RefundNotificationEmail, RegistrationConfirmationEmail, WelcomeEmail } from "./templates"
 
 export interface SendEmailOptions {
 	to: string | string[]
@@ -155,5 +155,36 @@ export class MailService {
 				template: RegistrationConfirmationEmail(emailProps),
 			})
 		}
+	}
+
+	async sendRefundNotification(
+		email: string,
+		userName: string,
+		event: ClubEvent,
+		refundAmount: number,
+		refundCode: string,
+	): Promise<void> {
+		const websiteUrl = this.configService.getOrThrow<string>("WEBSITE_URL")
+		const eventUrl = `${websiteUrl}${getEventUrl(event)}`
+
+		const eventDate = new Date(event.startDate).toLocaleDateString("en-US", {
+			weekday: "long",
+			month: "long",
+			day: "numeric",
+			year: "numeric",
+		})
+
+		await this.sendEmail({
+			to: email,
+			subject: `Refund Notification: ${event.name}`,
+			template: RefundNotificationEmail({
+				userName,
+				eventName: event.name,
+				eventUrl,
+				eventDate,
+				totalRefund: formatCurrency(refundAmount),
+				refundConfirmationCode: refundCode,
+			}),
+		})
 	}
 }

--- a/apps/api/src/stripe/stripe.controller.ts
+++ b/apps/api/src/stripe/stripe.controller.ts
@@ -51,10 +51,10 @@ export class StripeController {
 				this.webhookService.handlePaymentIntentFailed(event.data.object)
 				break
 			case "refund.created":
-				this.webhookService.handleRefundCreated(event.data.object)
+				await this.webhookService.handleRefundCreated(event.data.object)
 				break
 			case "refund.updated":
-				this.webhookService.handleRefundUpdated(event.data.object)
+				await this.webhookService.handleRefundUpdated(event.data.object)
 				break
 			default:
 				this.logger.log(`Unhandled event type: ${event.type}`)


### PR DESCRIPTION
## Summary
- Add POST /stripe/webhook endpoint with signature verification
- Handle payment_intent.succeeded: confirm payment, mark fees paid, transition slots X→R, send confirmation email
- Handle payment_intent.payment_failed: log failure (TODO: admin notification)
- Handle refund.created: create refund record, get/create system user as issuer, send notification email
- Handle refund.updated: confirm refund when status=succeeded

## Test plan
- [ ] Verify webhook signature validation rejects invalid signatures
- [ ] Test payment_intent.succeeded updates payment, fees, slots correctly
- [ ] Test refund.created creates record with idempotency
- [ ] Test refund.updated confirms refund on succeeded status
- [ ] Verify emails sent for payment confirmation and refund notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated refund notifications: Users now receive email notifications when refunds are processed, containing refund amounts, confirmation codes, and associated event information.
  * Complete refund webhook processing with idempotent refund creation, status tracking, and confirmation workflows ensures reliable and trackable refund handling throughout the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->