### PR TITLE
Use GitHub vars for non-sensitive deploy config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,9 +30,9 @@ jobs:
       - name: Deploy API to CapRover
         run: |
           caprover deploy \
-            --caproverUrl ${{ secrets.CAPROVER_URL }} \
+            --caproverUrl ${{ vars.CAPROVER_URL }} \
             --caproverPassword ${{ secrets.CAPROVER_PASSWORD }} \
-            --appName ${{ secrets.CAPROVER_API_APP }} \
+            --appName ${{ vars.CAPROVER_API_APP }} \
             --tarFile deploy-api.tar
 
   deploy-web:
@@ -46,7 +46,7 @@ jobs:
 
       - name: Create deployment tarball
         run: |
-          tar -cvf deploy-web.tar \
+          tar -cvf deploy-admin.tar \
             --exclude='node_modules' \
             --exclude='.git' \
             --exclude='apps/api' \
@@ -56,10 +56,10 @@ jobs:
             apps/web \
             packages/domain
 
-      - name: Deploy Web to CapRover
+      - name: Deploy Admin to CapRover
         run: |
           caprover deploy \
-            --caproverUrl ${{ secrets.CAPROVER_URL }} \
+            --caproverUrl ${{ vars.CAPROVER_URL }} \
             --caproverPassword ${{ secrets.CAPROVER_PASSWORD }} \
-            --appName ${{ secrets.CAPROVER_WEB_APP }} \
-            --tarFile deploy-web.tar
+            --appName ${{ vars.CAPROVER_ADMIN_APP }} \
+            --tarFile deploy-admin.tar

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -98,6 +98,8 @@ SSH into your droplet:
 ssh root@YOUR_DROPLET_IP
 ```
 
+apt update and apt upgrade, then reboot
+
 Install Docker if not present:
 
 ```bash
@@ -189,7 +191,7 @@ DATABASE_URL=mysql://user:pass@managed-db-host:25060/dbname?ssl={"rejectUnauthor
 ### 2.2 Create Web App
 
 1. Click "Apps" → "Create New App"
-2. App name: `bhmc-web`
+2. App name: `bhmc-admin`
 3. Click "Create New App"
 
 Configure the app:
@@ -201,7 +203,7 @@ Configure the app:
 ```
 NODE_ENV=production
 PORT=3000
-API_URL=https://api.yourdomain.com
+API_URL=https://api.bhmc.org
 # Add other env vars from apps/web/.env.example
 ```
 
@@ -215,12 +217,17 @@ Go to GitHub repo → Settings → Secrets and variables → Actions.
 
 Add these secrets:
 
-| Secret              | Value                            |
-| ------------------- | -------------------------------- |
-| `CAPROVER_URL`      | `https://captain.yourdomain.com` |
-| `CAPROVER_PASSWORD` | Your CapRover password           |
-| `CAPROVER_API_APP`  | `bhmc-api`                       |
-| `CAPROVER_WEB_APP`  | `bhmc-web`                       |
+| Secret              | Value                  |
+| ------------------- | ---------------------- |
+| `CAPROVER_PASSWORD` | Your CapRover password |
+
+Add these variables:
+
+| Secret               | Value                                         |
+| -------------------- | --------------------------------------------- |
+| `CAPROVER_URL`       | `https://captain.captain.mycaptain.bhmc.org/` |
+| `CAPROVER_API_APP`   | `bhmc-api`                                    |
+| `CAPROVER_ADMIN_APP` | `bhmc-admin`                                  |
 
 ### 3.2 Workflow File
 


### PR DESCRIPTION
## Summary
- Switch from `secrets.*` to `vars.*` for CAPROVER_URL, CAPROVER_API_APP, CAPROVER_ADMIN_APP
- Rename "web" references to "admin" in deploy workflow
- Update DEPLOYMENT.md with correct variable/secret configuration

## Test plan
- [ ] Verify GitHub vars are configured in repo settings
- [ ] Trigger deployment via tag push
- [ ] Confirm both apps deploy successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced deployment guide with additional system setup instructions (package updates and reboot procedures).
  * Clarified environment variables and configuration details for deployment process.
  * Updated API endpoint and deployment app naming references for consistency.

* **Chores**
  * Updated deployment workflow configuration variables and naming conventions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->