### PR TITLE
Add NEXT_PUBLIC_DJANGO_API_URL to prod build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,10 @@ jobs:
         run: |
           echo '{"schemaVersion":2,"dockerfilePath":"./apps/web/Dockerfile"}' > captain-definition
 
+      - name: Create production env file
+        run: |
+          echo "NEXT_PUBLIC_DJANGO_API_URL=${{ vars.NEXT_PUBLIC_DJANGO_API_URL }}" > apps/web/.env.production
+
       - name: Create deployment tarball
         run: |
           tar -cvf deploy-admin.tar \

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -17,6 +17,9 @@ SEED_ADMIN_PASSWORD=super_secret
 # Backend API URL for server-side calls
 API_URL=http://localhost:3333
 
+# Django API URL for client-side auth
+NEXT_PUBLIC_DJANGO_API_URL=http://localhost:8000
+
 # Next.js runtime env examples
 NODE_ENV=development
 PORT=3000


### PR DESCRIPTION
## Summary
- Workflow creates `.env.production` with `NEXT_PUBLIC_DJANGO_API_URL` from GitHub var before tarball
- Fixes client-side auth calls defaulting to `localhost:8000` in production
- Updates `.env.example` to document the variable

## Required action
Add `NEXT_PUBLIC_DJANGO_API_URL` = `https://data.bhmc.org` to GitHub repo variables (Settings > Secrets and variables > Actions > Variables)

## Test plan
- [ ] Add GitHub variable before merge
- [ ] After deploy, verify login calls `https://data.bhmc.org/auth/token/login/` in network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced production deployment configuration to properly set Django API URL during builds, ensuring correct API connectivity in production environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->