### PR TITLE
Center event header text, fix lint errors

### DIFF
--- a/apps/api/src/registration/__tests__/admin-registration.service.test.ts
+++ b/apps/api/src/registration/__tests__/admin-registration.service.test.ts
@@ -4,7 +4,6 @@ import {
 	EventTypeChoices,
 	type CompleteClubEvent,
 	type AdminRegistration,
-	type Player,
 	type DjangoUser,
 } from "@repo/domain/types"
 
@@ -12,7 +11,7 @@ import { SlotConflictError, EventFullError } from "../errors"
 import { AdminRegistrationService } from "../services/admin-registration.service"
 
 jest.mock("@repo/domain/functions", () => ({
-	getAmount: jest.fn((eventFee) => 50),
+	getAmount: jest.fn(() => 50),
 	calculateAmountDue: jest.fn((amounts: number[]) => ({
 		total: amounts.reduce((a, b) => a + b, 0),
 		transactionFee: amounts.reduce((a, b) => a + b, 0) * 0.029 + 0.3,

--- a/apps/api/src/registration/services/player.service.ts
+++ b/apps/api/src/registration/services/player.service.ts
@@ -59,7 +59,7 @@ export class PlayerService {
 		try {
 			const player = await this.repository.findPlayerById(playerId)
 			return toPlayer(player)
-		} catch (error) {
+		} catch {
 			throw new NotFoundException(`Player ${playerId} not found`)
 		}
 	}

--- a/apps/web/app/events/[eventId]/layout.tsx
+++ b/apps/web/app/events/[eventId]/layout.tsx
@@ -81,12 +81,12 @@ export default function EventLayout({ children }: { children: React.ReactNode })
 		<div>
 			{isReportsPage ? (
 				<div className="p-0">
-					<h2 className="text-xl font-bold text-primary">{headerText}</h2>
+					<h2 className="text-xl font-bold text-primary text-center">{headerText}</h2>
 				</div>
 			) : (
 				<div className="flex justify-center md:px-8 pt-4 md:pt-8">
 					<div className="w-full max-w-3xl px-4 md:px-0">
-						<h2 className="text-xl font-bold text-primary">{headerText}</h2>
+						<h2 className="text-xl font-bold text-primary text-center">{headerText}</h2>
 					</div>
 				</div>
 			)}


### PR DESCRIPTION
## Summary
- Center event date/name header text so it aligns visually regardless of varying content widths below
- Fix pre-existing lint errors (unused imports and variables)

## Test plan
- [ ] Navigate to `/events/{id}` - header should be centered
- [ ] Check `/events/{id}/players` and `/events/{id}/golf-genius` - header remains centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved event page header alignment with centered text

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->