### PR TITLE
Extract inline select functions to stable mappers

### DIFF
--- a/apps/public/src/hooks/use-aces.ts
+++ b/apps/public/src/hooks/use-aces.ts
@@ -3,12 +3,14 @@ import { useQuery } from "@tanstack/react-query"
 import { Ace, AceApiSchema, AceData } from "../models/ace"
 import { getMany } from "../utils/api-client"
 
+const mapper = (data: AceData[]) => data.map((ace) => new Ace(ace))
+
 export function useAces(season: number) {
 	const endpoint = `aces/?season=${season}`
 
 	return useQuery({
 		queryKey: [endpoint],
 		queryFn: () => getMany<AceData>(endpoint, AceApiSchema),
-		select: (data) => data.map((ace) => new Ace(ace)),
+		select: mapper,
 	})
 }

--- a/apps/public/src/hooks/use-board-members.ts
+++ b/apps/public/src/hooks/use-board-members.ts
@@ -3,11 +3,13 @@ import { useQuery } from "@tanstack/react-query"
 import { BoardMember, BoardMemberApiSchema, BoardMemberData } from "../models/board-member"
 import { getMany } from "../utils/api-client"
 
+const mapper = (data: BoardMemberData[]) => data.map((member) => new BoardMember(member))
+
 export function useBoardMembers() {
 	const endpoint = "board"
 	return useQuery({
 		queryKey: [endpoint],
 		queryFn: () => getMany<BoardMemberData>(endpoint, BoardMemberApiSchema),
-		select: (data) => data.map((member) => new BoardMember(member)),
+		select: mapper,
 	})
 }

--- a/apps/public/src/hooks/use-club-documents.ts
+++ b/apps/public/src/hooks/use-club-documents.ts
@@ -14,6 +14,12 @@ import {
 import { getMany, getOne, httpClient } from "../utils/api-client"
 import { apiUrl } from "../utils/api-utils"
 
+const clubDocumentCodesMapper = (data: ClubDocumentCodeData[] | undefined) =>
+	data?.map((code) => new ClubDocumentCode(code))
+const clubDocumentMapper = (data: ClubDocumentData | undefined) => new ClubDocument(data!)
+const clubDocumentsMapper = (data: ClubDocumentData[] | undefined) =>
+	data?.map((doc) => new ClubDocument(doc))
+
 interface ClubDocumentArgs {
 	documentId?: number
 	formData: FormData
@@ -24,7 +30,7 @@ export function useClubDocumentCodes() {
 	return useQuery({
 		queryKey: ["club-document-codes"],
 		queryFn: () => getMany<ClubDocumentCodeData>(endpoint, ClubDocumentCodeApiSchema),
-		select: (data) => data?.map((code) => new ClubDocumentCode(code)),
+		select: clubDocumentCodesMapper,
 	})
 }
 
@@ -33,7 +39,7 @@ export function useClubDocument(code: string) {
 	return useQuery({
 		queryKey: ["club-documents", code],
 		queryFn: () => getOne<ClubDocumentData>(endpoint, ClubDocumentApiSchema),
-		select: (data) => new ClubDocument(data!),
+		select: clubDocumentMapper,
 	})
 }
 
@@ -42,7 +48,7 @@ export function useClubDocuments() {
 	return useQuery({
 		queryKey: ["club-documents"],
 		queryFn: () => getMany<ClubDocumentData>(endpoint, ClubDocumentApiSchema),
-		select: (data) => data?.map((doc) => new ClubDocument(doc)),
+		select: clubDocumentsMapper,
 	})
 }
 

--- a/apps/public/src/hooks/use-club-event.ts
+++ b/apps/public/src/hooks/use-club-event.ts
@@ -3,13 +3,15 @@ import { useQuery } from "@tanstack/react-query"
 import { ClubEvent, ClubEventApiSchema, ClubEventData } from "../models/club-event"
 import { getOne } from "../utils/api-client"
 
+const mapper = (data: ClubEventData | undefined) => new ClubEvent(data!)
+
 export function useClubEvent(eventId: number | null) {
 	const endpoint = `events/${eventId}`
 
 	return useQuery({
 		queryKey: ["club-events", eventId],
 		queryFn: () => getOne<ClubEventData>(endpoint, ClubEventApiSchema),
-		select: (data) => new ClubEvent(data!),
+		select: mapper,
 		enabled: eventId !== null,
 	})
 }

--- a/apps/public/src/hooks/use-courses.ts
+++ b/apps/public/src/hooks/use-courses.ts
@@ -3,11 +3,13 @@ import { useQuery } from "@tanstack/react-query"
 import { Course, CourseApiSchema, CourseData } from "../models/course"
 import { getMany } from "../utils/api-client"
 
+const mapper = (data: CourseData[]) => data.map((c) => new Course(c))
+
 export function useCourses() {
 	const endpoint = "courses"
 	return useQuery({
 		queryKey: [endpoint],
 		queryFn: () => getMany<CourseData>(endpoint, CourseApiSchema),
-		select: (data) => data.map((c: CourseData) => new Course(c)),
+		select: mapper,
 	})
 }

--- a/apps/public/src/hooks/use-documents.ts
+++ b/apps/public/src/hooks/use-documents.ts
@@ -1,13 +1,15 @@
 import { useQuery } from "@tanstack/react-query"
 
-import { BhmcDocument, DocumentApiSchema } from "../models/document"
+import { BhmcDocument, DocumentApiSchema, DocumentData } from "../models/document"
 import { getMany } from "../utils/api-client"
+
+const mapper = (data: DocumentData[]) => data.map((doc) => new BhmcDocument(doc))
 
 export function useDocuments(documentType: string, year?: number | null) {
 	const endpoint = `documents/?type=${documentType}` + (year ? `&year=${year}` : "")
 	return useQuery({
 		queryKey: [endpoint],
 		queryFn: () => getMany(endpoint, DocumentApiSchema),
-		select: (data) => data.map((doc) => new BhmcDocument(doc)),
+		select: mapper,
 	})
 }

--- a/apps/public/src/hooks/use-event-documents.ts
+++ b/apps/public/src/hooks/use-event-documents.ts
@@ -10,11 +10,13 @@ interface DocumentArgs {
 	formData: FormData
 }
 
+const mapper = (data: DocumentData[]) => data.map((doc) => new BhmcDocument(doc))
+
 export function useEventDocuments(eventId: number) {
 	return useQuery({
 		queryKey: ["documents", eventId],
 		queryFn: () => getMany(`documents/?event_id=${eventId}`, DocumentApiSchema),
-		select: (data) => data.map((doc) => new BhmcDocument(doc)),
+		select: mapper,
 		staleTime: twoMinutes,
 		enabled: eventId > 0,
 	})

--- a/apps/public/src/hooks/use-event-registration-slots.ts
+++ b/apps/public/src/hooks/use-event-registration-slots.ts
@@ -1,7 +1,13 @@
 import { useQuery } from "@tanstack/react-query"
 
-import { RegistrationSlot, RegistrationSlotApiSchema } from "../models/registration"
+import {
+	RegistrationSlot,
+	RegistrationSlotApiSchema,
+	RegistrationSlotData,
+} from "../models/registration"
 import { getMany } from "../utils/api-client"
+
+const mapper = (data: RegistrationSlotData[]) => data.map((s) => new RegistrationSlot(s))
 
 export function useEventRegistrationSlots(eventId?: number) {
 	const endpoint = `registration-slots/?event_id=${eventId}`
@@ -9,8 +15,6 @@ export function useEventRegistrationSlots(eventId?: number) {
 		queryKey: ["event-registration-slots", eventId],
 		queryFn: () => getMany(endpoint, RegistrationSlotApiSchema),
 		enabled: !!eventId,
-		select: (data) => {
-			return data.map((s) => new RegistrationSlot(s))
-		},
+		select: mapper,
 	})
 }

--- a/apps/public/src/hooks/use-event-scores.ts
+++ b/apps/public/src/hooks/use-event-scores.ts
@@ -3,11 +3,13 @@ import { useQuery } from "@tanstack/react-query"
 import { PlayerRound, PlayerRoundApiSchema, PlayerRoundData } from "../models/scores"
 import { getMany } from "../utils/api-client"
 
+const mapper = (data: PlayerRoundData[]) => data.map((round) => new PlayerRound(round))
+
 export function useEventScores(eventId: number) {
 	const endpoint = `scores/?event=${eventId}`
 	return useQuery({
 		queryKey: ["scores", eventId],
 		queryFn: () => getMany<PlayerRoundData>(endpoint, PlayerRoundApiSchema),
-		select: (data) => data.map((round) => new PlayerRound(round)),
+		select: mapper,
 	})
 }

--- a/apps/public/src/hooks/use-low-scores.ts
+++ b/apps/public/src/hooks/use-low-scores.ts
@@ -3,12 +3,14 @@ import { useQuery } from "@tanstack/react-query"
 import { LowScore, LowScoreApiSchema, LowScoreData } from "../models/low-score"
 import { getMany } from "../utils/api-client"
 
+const mapper = (data: LowScoreData[]) => data.map((champ) => new LowScore(champ))
+
 export function useLowScores(season: number) {
 	const endpoint = `low-scores/?season=${season}`
 
 	return useQuery({
 		queryKey: ["low-scores"],
 		queryFn: () => getMany<LowScoreData>(endpoint, LowScoreApiSchema),
-		select: (data) => data.map((champ) => new LowScore(champ)),
+		select: mapper,
 	})
 }

--- a/apps/public/src/hooks/use-major-champions.ts
+++ b/apps/public/src/hooks/use-major-champions.ts
@@ -4,12 +4,14 @@ import { ClubEvent } from "../models/club-event"
 import { MajorChampion, MajorChampionApiSchema, MajorChampionData } from "../models/major-champion"
 import { getMany } from "../utils/api-client"
 
+const mapper = (data: MajorChampionData[]) => data.map((champ) => new MajorChampion(champ))
+
 export function useChampions(season: number) {
 	return useQuery({
 		queryKey: ["champions", season],
 		queryFn: () =>
 			getMany<MajorChampionData>(`champions/?season=${season}`, MajorChampionApiSchema),
-		select: (data) => data.map((champ) => new MajorChampion(champ)),
+		select: mapper,
 	})
 }
 
@@ -18,6 +20,6 @@ export function useEventChampions(clubEvent: ClubEvent) {
 		queryKey: ["champions", clubEvent.season, clubEvent.id],
 		queryFn: () =>
 			getMany<MajorChampionData>(`champions/?event=${clubEvent.id}`, MajorChampionApiSchema),
-		select: (data) => data.map((champ) => new MajorChampion(champ)),
+		select: mapper,
 	})
 }

--- a/apps/public/src/hooks/use-my-events.ts
+++ b/apps/public/src/hooks/use-my-events.ts
@@ -1,11 +1,18 @@
 import { useQuery } from "@tanstack/react-query"
 
 import { RegistrationStatus } from "../models/codes"
-import { RegistrationSlotApiSchema } from "../models/registration"
+import { RegistrationSlotApiSchema, RegistrationSlotData } from "../models/registration"
 import { getMany } from "../utils/api-client"
 import { currentSeason } from "../utils/app-config"
 import { useAuth } from "./use-auth"
 import { useMyPlayerRecord } from "./use-my-player-record"
+
+const mapper = (data: RegistrationSlotData[]) =>
+	data
+		.filter(
+			(s) => s.status === RegistrationStatus.Reserved || s.status === RegistrationStatus.Processing,
+		)
+		.map((e) => e.event)
 
 export function useMyEvents() {
 	const { user } = useAuth()
@@ -17,14 +24,7 @@ export function useMyEvents() {
 	return useQuery({
 		queryKey: ["my-events"],
 		queryFn: () => getMany(endpoint, RegistrationSlotApiSchema),
-		select: (data) => {
-			return data
-				.filter(
-					(s) =>
-						s.status === RegistrationStatus.Reserved || s.status === RegistrationStatus.Processing,
-				)
-				.map((e) => e.event)
-		},
+		select: mapper,
 		enabled: enable,
 	})
 }

--- a/apps/public/src/hooks/use-my-player-record.ts
+++ b/apps/public/src/hooks/use-my-player-record.ts
@@ -5,6 +5,8 @@ import { getOne, httpClient } from "../utils/api-client"
 import { apiUrl } from "../utils/api-utils"
 import { useAuth } from "./use-auth"
 
+const mapper = (data: PlayerApiData | null | undefined) => new Player(data!)
+
 export function useMyPlayerRecord() {
 	const { user } = useAuth()
 	const queryClient = useQueryClient()
@@ -17,7 +19,7 @@ export function useMyPlayerRecord() {
 			return queryClient.getQueryData<PlayerApiData | null>(["player", email])
 		},
 		enabled: email !== undefined && email !== "unknown",
-		select: (data) => new Player(data),
+		select: mapper,
 	})
 }
 

--- a/apps/public/src/hooks/use-open-slots.ts
+++ b/apps/public/src/hooks/use-open-slots.ts
@@ -1,7 +1,13 @@
 import { useQuery } from "@tanstack/react-query"
 
-import { RegistrationSlot, RegistrationSlotApiSchema } from "../models/registration"
+import {
+	RegistrationSlot,
+	RegistrationSlotApiSchema,
+	RegistrationSlotData,
+} from "../models/registration"
 import { getMany } from "../utils/api-client"
+
+const mapper = (data: RegistrationSlotData[]) => data.map((s) => new RegistrationSlot(s))
 
 export function useOpenSlots(eventId: number, holeId: number, startingOrder: number) {
 	const endpoint = `registration-slots/?event_id=${eventId}&hole_id=${holeId}&starting_order=${startingOrder}&is_open=True`
@@ -11,6 +17,6 @@ export function useOpenSlots(eventId: number, holeId: number, startingOrder: num
 		enabled: !!eventId && !!holeId && startingOrder != null,
 		staleTime: Infinity,
 		gcTime: 0,
-		select: (data) => data.map((s) => new RegistrationSlot(s)),
+		select: mapper,
 	})
 }

--- a/apps/public/src/hooks/use-payments.ts
+++ b/apps/public/src/hooks/use-payments.ts
@@ -4,13 +4,16 @@ import { httpClient } from "../utils/api-client"
 import { apiUrl, serverUrl } from "../utils/api-utils"
 import { StripeAmount } from "../models/payment"
 
+const stripeAmountMapper = (data: unknown) => data as StripeAmount
+const clientSecretMapper = (data: { client_secret: string }) => data.client_secret
+
 export function usePaymentAmount(paymentId: number) {
 	const endpoint = serverUrl(`payments/${paymentId}/stripe-amount/`)
 	return useQuery({
 		queryKey: [endpoint],
 		queryFn: () => httpClient(endpoint),
 		staleTime: 0,
-		select: (data) => data as StripeAmount,
+		select: stripeAmountMapper,
 	})
 }
 
@@ -20,6 +23,6 @@ export function useCustomerSession() {
 		queryKey: [endpoint],
 		queryFn: () => httpClient(endpoint, { method: "POST", body: JSON.stringify({}) }),
 		staleTime: 0,
-		select: (data) => data.client_secret,
+		select: clientSecretMapper,
 	})
 }

--- a/apps/public/src/hooks/use-photo.ts
+++ b/apps/public/src/hooks/use-photo.ts
@@ -1,8 +1,11 @@
 import { useMutation, useQuery } from "@tanstack/react-query"
 
-import { Photo, PhotoApiSchema } from "../models/photo"
+import { Photo, PhotoApiSchema, PhotoData } from "../models/photo"
 import { getMany, getOne, httpClient } from "../utils/api-client"
 import { apiUrl } from "../utils/api-utils"
+
+const photosMapper = (data: PhotoData[]) => data.map((photo) => new Photo(photo))
+const photoMapper = (data: PhotoData | undefined) => (data ? new Photo(data) : undefined)
 
 export function usePhotos(season: number, tags: string[]) {
 	const taglist = tags.map((tag) => `tags=${tag}`).join("&")
@@ -10,7 +13,7 @@ export function usePhotos(season: number, tags: string[]) {
 	return useQuery({
 		queryKey: [endpoint],
 		queryFn: () => getMany(endpoint, PhotoApiSchema),
-		select: (data) => data.map((photo) => new Photo(photo)),
+		select: photosMapper,
 	})
 }
 
@@ -19,11 +22,7 @@ export function usePhoto(photoId: number) {
 	return useQuery({
 		queryKey: [endpoint],
 		queryFn: () => getOne(endpoint, PhotoApiSchema),
-		select: (data) => {
-			if (data) {
-				return new Photo(data)
-			}
-		},
+		select: photoMapper,
 	})
 }
 

--- a/apps/public/src/hooks/use-player-aces.ts
+++ b/apps/public/src/hooks/use-player-aces.ts
@@ -3,12 +3,14 @@ import { useQuery } from "@tanstack/react-query"
 import { Ace, AceApiSchema, AceData } from "../models/ace"
 import { getMany } from "../utils/api-client"
 
+const mapper = (data: AceData[]) => data.map((ace) => new Ace(ace))
+
 export function usePlayerAces(playerId: number) {
 	const endpoint = `aces/?player_id=${playerId}`
 
 	return useQuery({
 		queryKey: [endpoint],
 		queryFn: () => getMany<AceData>(endpoint, AceApiSchema),
-		select: (data) => data.map((ace) => new Ace(ace)),
+		select: mapper,
 	})
 }

--- a/apps/public/src/hooks/use-player-champions.ts
+++ b/apps/public/src/hooks/use-player-champions.ts
@@ -3,12 +3,14 @@ import { useQuery } from "@tanstack/react-query"
 import { MajorChampion, MajorChampionApiSchema, MajorChampionData } from "../models/major-champion"
 import { getMany } from "../utils/api-client"
 
+const mapper = (data: MajorChampionData[]) => data.map((champ) => new MajorChampion(champ))
+
 export function usePlayerChampionships(playerId: number) {
 	const endpoint = `champions/?player=${playerId}`
 
 	return useQuery({
 		queryKey: [endpoint],
 		queryFn: () => getMany<MajorChampionData>(endpoint, MajorChampionApiSchema),
-		select: (data) => data.map((champ) => new MajorChampion(champ)),
+		select: mapper,
 	})
 }

--- a/apps/public/src/hooks/use-player-events.ts
+++ b/apps/public/src/hooks/use-player-events.ts
@@ -5,14 +5,16 @@ import { RegistrationSlotApiSchema, RegistrationSlotData } from "../models/regis
 import { getMany } from "../utils/api-client"
 import { currentSeason, twoMinutes } from "../utils/app-config"
 
+const mapper = (data: RegistrationSlotData[]) =>
+	data.filter((d) => d.status === RegistrationStatus.Reserved).map((r) => r.event)
+
 export function usePlayerEvents(playerId: number) {
 	const endpoint = `registration-slots/?player_id=${playerId}&seasons=${currentSeason}&seasons=${currentSeason - 1}`
 
 	return useQuery({
 		queryKey: [endpoint],
 		queryFn: () => getMany<RegistrationSlotData>(endpoint, RegistrationSlotApiSchema),
-		select: (data) =>
-			data.filter((d) => d.status === RegistrationStatus.Reserved).map((r) => r.event),
+		select: mapper,
 		staleTime: twoMinutes,
 	})
 }

--- a/apps/public/src/hooks/use-player-registration-slots.ts
+++ b/apps/public/src/hooks/use-player-registration-slots.ts
@@ -1,15 +1,21 @@
 import { useQuery } from "@tanstack/react-query"
 
-import { RegistrationSlot, RegistrationSlotApiSchema } from "../models/registration"
+import {
+	RegistrationSlot,
+	RegistrationSlotApiSchema,
+	RegistrationSlotData,
+} from "../models/registration"
 import { getMany } from "../utils/api-client"
 import { twoMinutes } from "../utils/app-config"
+
+const mapper = (data: RegistrationSlotData[]) => data.map((s) => new RegistrationSlot(s))
 
 export function usePlayerRegistrationSlots(playerId: number) {
 	const endpoint = `registration-slots/?player_id=${playerId}`
 	return useQuery({
 		queryKey: ["player-registration-slots", playerId],
 		queryFn: () => getMany(endpoint, RegistrationSlotApiSchema),
-		select: (data) => data.map((s) => new RegistrationSlot(s)),
+		select: mapper,
 		staleTime: twoMinutes,
 	})
 }

--- a/apps/public/src/hooks/use-player-registrations.ts
+++ b/apps/public/src/hooks/use-player-registrations.ts
@@ -1,15 +1,19 @@
 import { useQuery } from "@tanstack/react-query"
 
-import { Registration, RegistrationApiSchema } from "../models/registration"
+import { Registration, RegistrationApiSchema, RegistrationData } from "../models/registration"
 import { getMany, getOne } from "../utils/api-client"
 import { twoMinutes } from "../utils/app-config"
+
+const registrationsMapper = (data: RegistrationData[]) => data.map((r) => new Registration(r))
+const registrationMapper = (data: RegistrationData | undefined) =>
+	data ? new Registration(data) : null
 
 export function usePlayerRegistrations(playerId?: number, season?: number) {
 	const endpoint = `registration/?player_id=${playerId}` + (season ? `&seasons=${season}` : "")
 	return useQuery({
 		queryKey: ["player-registrations", playerId],
 		queryFn: () => getMany(endpoint, RegistrationApiSchema),
-		select: (data) => data.map((r) => new Registration(r)),
+		select: registrationsMapper,
 		staleTime: twoMinutes,
 		enabled: playerId !== undefined && playerId > 0,
 	})
@@ -21,7 +25,7 @@ export function usePlayerRegistration(playerId?: number, eventId?: number) {
 	return useQuery({
 		queryKey: ["player-registration", playerId, eventId],
 		queryFn: () => getOne(endpoint, RegistrationApiSchema),
-		select: (data) => (data ? new Registration(data) : null),
+		select: registrationMapper,
 		staleTime: twoMinutes,
 		enabled: playerId !== undefined && playerId > 0 && eventId !== undefined && eventId > 0,
 	})

--- a/apps/public/src/hooks/use-player.ts
+++ b/apps/public/src/hooks/use-player.ts
@@ -3,16 +3,14 @@ import { useQuery } from "@tanstack/react-query"
 import { Player, PlayerApiData, PlayerApiSchema } from "../models/player"
 import { getOne } from "../utils/api-client"
 
+const mapper = (data: PlayerApiData | undefined) => (data ? new Player(data) : undefined)
+
 export function usePlayer(playerId: number) {
 	const endpoint = `players/${playerId}`
 
 	return useQuery({
 		queryKey: [endpoint],
 		queryFn: () => getOne<PlayerApiData>(endpoint, PlayerApiSchema),
-		select: (data) => {
-			if (data) {
-				return new Player(data)
-			}
-		},
+		select: mapper,
 	})
 }

--- a/apps/public/src/hooks/use-players.ts
+++ b/apps/public/src/hooks/use-players.ts
@@ -6,11 +6,13 @@ import { apiUrl } from "../utils/api-utils"
 
 const endpoint = "players"
 
+const mapper = (data: PlayerApiData[]) => data.map((player) => new Player(player))
+
 export function usePlayers() {
 	return useQuery({
 		queryKey: [endpoint],
 		queryFn: () => getMany<PlayerApiData>(endpoint, PlayerApiSchema),
-		select: (data) => data.map((player) => new Player(player)),
+		select: mapper,
 	})
 }
 

--- a/apps/public/src/hooks/use-random-photos.ts
+++ b/apps/public/src/hooks/use-random-photos.ts
@@ -1,7 +1,9 @@
 import { useQuery } from "@tanstack/react-query"
 
-import { Photo, PhotoApiSchema } from "../models/photo"
+import { Photo, PhotoApiSchema, PhotoData } from "../models/photo"
 import { getMany } from "../utils/api-client"
+
+const mapper = (data: PhotoData[]) => data.map((p) => new Photo(p))
 
 export function useRandomPhotos(take: number, tag: string | undefined) {
 	const getUrl = () => {
@@ -16,7 +18,7 @@ export function useRandomPhotos(take: number, tag: string | undefined) {
 	return useQuery({
 		queryKey: ["random-photos", tag ?? "none"],
 		queryFn: () => getMany(url, PhotoApiSchema),
-		select: (data) => data.map((p) => new Photo(p)),
+		select: mapper,
 		staleTime: 0,
 	})
 }

--- a/apps/public/src/hooks/use-season-long-points.ts
+++ b/apps/public/src/hooks/use-season-long-points.ts
@@ -10,6 +10,9 @@ import {
 } from "../models/points"
 import { getMany } from "../utils/api-client"
 
+const topPointsMapper = (data: TopPointsData[]) => data.map((pt) => new TopPoints(pt))
+const playerPointsMapper = (data: PlayerPointsData[]) => data.map((pp) => new PlayerPoints(pp))
+
 interface TopPointsArgs {
 	season: number
 	topN: number
@@ -22,7 +25,7 @@ export function useTopPoints({ season, topN, category }: TopPointsArgs) {
 	return useQuery({
 		queryKey: ["season-long-points", season, category, topN],
 		queryFn: () => getMany<TopPointsData>(endpoint, TopPointsSchema),
-		select: (data) => data.map((pt) => new TopPoints(pt)),
+		select: topPointsMapper,
 	})
 }
 
@@ -47,7 +50,7 @@ export function useSeasonLongPoints({ season, eventId, playerId }: SeasonLongPoi
 	return useQuery({
 		queryKey: ["season-long-points", season ?? 0, playerId ?? 0, eventId ?? 0],
 		queryFn: () => getMany<PlayerPointsData>(endpoint, PlayerPointsApiSchema),
-		select: (data) => data.map((pp) => new PlayerPoints(pp)),
+		select: playerPointsMapper,
 	})
 }
 
@@ -56,7 +59,7 @@ export function usePlayerPoints({ season, playerId }: SeasonLongPointsArgs) {
 	return useQuery({
 		queryKey: ["season-long-points", season, playerId],
 		queryFn: () => getMany<PlayerPointsData>(endpoint, PlayerPointsApiSchema),
-		select: (data) => data.map((pp) => new PlayerPoints(pp)),
+		select: playerPointsMapper,
 		enabled: playerId !== undefined,
 	})
 }

--- a/apps/public/src/hooks/use-tags.ts
+++ b/apps/public/src/hooks/use-tags.ts
@@ -1,7 +1,9 @@
 import { useQuery } from "@tanstack/react-query"
 
-import { Tag, TagApiSchema } from "../models/tag"
+import { Tag, TagApiSchema, TagData } from "../models/tag"
 import { getMany } from "../utils/api-client"
+
+const mapper = (data: TagData[]) => data.map((t) => new Tag(t))
 
 export function useTags() {
 	const endpoint = "tags"
@@ -9,6 +11,6 @@ export function useTags() {
 	return useQuery({
 		queryKey: [endpoint],
 		queryFn: () => getMany(endpoint, TagApiSchema),
-		select: (data) => data.map((t) => new Tag(t)),
+		select: mapper,
 	})
 }

--- a/apps/public/src/hooks/use-tournament-results.ts
+++ b/apps/public/src/hooks/use-tournament-results.ts
@@ -10,6 +10,11 @@ import {
 } from "../models/tournament-results"
 import { getMany } from "../utils/api-client"
 
+const resultsMapper = (data: TournamentResultData[]) =>
+	data.map((result) => new TournamentResult(result))
+const pointsMapper = (data: TournamentPointsData[]) =>
+	data.map((points) => new TournamentPoints(points))
+
 interface TournamentResultsArgs {
 	playerId?: number
 	season?: number
@@ -27,7 +32,7 @@ export function useTournamentResults({ playerId, season }: TournamentResultsArgs
 	return useQuery({
 		queryKey: ["tournament-results", playerId ?? 0, season ?? 0],
 		queryFn: () => getMany<TournamentResultData>(endpoint, TournamentResultApiSchema),
-		select: (data) => data.map((result) => new TournamentResult(result)),
+		select: resultsMapper,
 		enabled: playerId !== undefined && playerId > 0,
 	})
 }
@@ -49,7 +54,7 @@ export function useTournamentPoints({ playerId, season }: TournamentPointsArgs) 
 	return useQuery({
 		queryKey: ["tournament-points", playerId ?? 0, season ?? 0],
 		queryFn: () => getMany<TournamentPointsData>(endpoint, TournamentPointsApiSchema),
-		select: (data) => data.map((points) => new TournamentPoints(points)),
+		select: pointsMapper,
 		enabled: playerId !== undefined && playerId > 0,
 	})
 }


### PR DESCRIPTION
## Summary
- Extract inline `select` callbacks in React Query hooks to stable mapper functions
- Prevents unnecessary re-renders when returned data is used as useEffect dependencies
- Refactored 28 hook files in apps/public/src/hooks/

## Test plan
- [x] `pnpm --filter public test` passes
- [x] `pnpm --filter public build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization by consolidating data transformation logic across multiple hooks, replacing inline mapping functions with named mapper helpers. No changes to user-facing functionality or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->