### PR TITLE
fix: handle two-day tournaments in Golf Genius sync and results import

### DIFF
--- a/apps/api/src/golfgenius/api-data/tournament.ts
+++ b/apps/api/src/golfgenius/api-data/tournament.ts
@@ -27,6 +27,7 @@ import { z } from "zod"
 export const GgTournamentSchema = z.object({
 	id: z.string(),
 	name: z.string(),
+	tournament_spec_id: z.string().nullish(),
 	score_format: z.string(),
 	handicap_format: z.string(),
 	score_scope: z.string(),

--- a/apps/api/src/golfgenius/services/__tests__/event-sync.service.test.ts
+++ b/apps/api/src/golfgenius/services/__tests__/event-sync.service.test.ts
@@ -1,0 +1,355 @@
+import { EventSyncService } from "../event-sync.service"
+
+// =============================================================================
+// Test Fixtures — shapes taken from real Golf Genius responses for the
+// 2026 Senior Club Championship (a two-day event).
+// =============================================================================
+
+const ggEvent = { id: "evt-1", website: "www.golfgenius.com/pages/1" }
+
+const ggRound1 = { id: "r1", index: 1, event_id: "evt-1", date: "2026-08-01" }
+const ggRound2 = { id: "r2", index: 2, event_id: "evt-1", date: "2026-08-02" }
+
+function ggTournament(overrides: Record<string, unknown>) {
+	return {
+		id: "t-default",
+		name: "Default Tournament",
+		tournament_spec_id: "spec-default",
+		score_format: "stroke",
+		handicap_format: "usga_net",
+		score_scope: "member",
+		result_scope: "rs_flight",
+		score_aggregation: null,
+		...overrides,
+	}
+}
+
+// A two-day cumulative tournament: listed under BOTH rounds with the same id.
+// Note the "Gross" tournament reports a net handicap_format (real GG behavior
+// for flighted gross/net pairs).
+const grossChampionship = ggTournament({
+	id: "champ-gross-new",
+	name: "Gross Senior Championship - Senior Division",
+	tournament_spec_id: "spec-champ",
+	handicap_format: "usga_net",
+})
+
+const netChampionship = ggTournament({
+	id: "champ-net-new",
+	name: "Net Senior Championship - Senior Division",
+	tournament_spec_id: "spec-champ",
+	handicap_format: "usga_net",
+})
+
+// Round-specific tournaments
+const saturdaySkins = ggTournament({
+	id: "skins-sat",
+	name: "Saturday Senior Gross Skins - Senior Skins",
+	tournament_spec_id: "spec-skins-sat",
+	score_format: "skins",
+	handicap_format: "gross",
+})
+
+const sundaySkins = ggTournament({
+	id: "skins-sun",
+	name: "Sunday Senior Gross Skins - Senior Skins",
+	tournament_spec_id: "spec-skins-sun",
+	score_format: "skins",
+	handicap_format: "gross",
+})
+
+const localEvent = {
+	id: 10,
+	name: "Senior Club Championship",
+	startDate: "2026-08-01",
+	ggId: null,
+	portalUrl: null,
+}
+
+// =============================================================================
+// Mock Setup
+// =============================================================================
+
+function createMocks(options?: {
+	existingRounds?: unknown[]
+	existingTournaments?: unknown[]
+	rounds?: unknown[]
+	tournamentsByRound?: Record<string, unknown[]>
+}) {
+	let nextId = 100
+	const apiClient = {
+		findMatchingEventByStartDate: jest.fn().mockResolvedValue(ggEvent),
+		getEventRounds: jest.fn().mockResolvedValue(options?.rounds ?? [ggRound1, ggRound2]),
+		getRoundTournaments: jest
+			.fn()
+			.mockImplementation((_eventId: string, roundId: string) =>
+				Promise.resolve(options?.tournamentsByRound?.[roundId] ?? []),
+			),
+	}
+	const events = {
+		findEventById: jest.fn().mockResolvedValue({ ...localEvent }),
+		updateEvent: jest.fn().mockResolvedValue(undefined),
+		findRoundsByEventId: jest.fn().mockResolvedValue(options?.existingRounds ?? []),
+		updateRound: jest.fn().mockResolvedValue(undefined),
+		createRound: jest.fn().mockImplementation(() => Promise.resolve({ id: nextId++ })),
+		findTournamentsByEventId: jest.fn().mockResolvedValue(options?.existingTournaments ?? []),
+		updateTournament: jest.fn().mockResolvedValue(undefined),
+		createTournament: jest.fn().mockImplementation(() => Promise.resolve({ id: nextId++ })),
+	}
+	const courses = {}
+	const service = new EventSyncService(apiClient as any, events as any, courses as any)
+	return { service, apiClient, events }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("EventSyncService.syncEvent", () => {
+	describe("two-day events", () => {
+		it("creates a cross-round tournament once, bound to the first round", async () => {
+			const { service, events } = createMocks({
+				tournamentsByRound: {
+					r1: [grossChampionship, saturdaySkins],
+					r2: [grossChampionship, sundaySkins],
+				},
+			})
+
+			const summary = await service.syncEvent(10)
+
+			expect(summary.tournamentsCreated).toBe(3)
+			expect(summary.tournamentsUpdated).toBe(0)
+			expect(summary.errors).toEqual([])
+
+			const created = events.createTournament.mock.calls.map((c) => c[0])
+			const champ = created.filter((d) => d.ggId === "champ-gross-new")
+			expect(champ).toHaveLength(1)
+			// Bound to round 1 (the first local round id created is 100)
+			expect(champ[0].roundId).toBe(100)
+			expect(champ[0].ggSpecId).toBe("spec-champ")
+		})
+
+		it("keeps the first-round binding when re-syncing an existing cross-round tournament", async () => {
+			const existing = {
+				id: 55,
+				name: grossChampionship.name,
+				ggId: "champ-gross-new",
+				ggSpecId: "spec-champ",
+			}
+			const { service, events } = createMocks({
+				existingRounds: [
+					{ id: 1, ggId: "r1" },
+					{ id: 2, ggId: "r2" },
+				],
+				existingTournaments: [existing],
+				tournamentsByRound: {
+					r1: [grossChampionship],
+					r2: [grossChampionship],
+				},
+			})
+
+			const summary = await service.syncEvent(10)
+
+			expect(summary.tournamentsUpdated).toBe(1)
+			expect(summary.tournamentsCreated).toBe(0)
+			expect(events.updateTournament).toHaveBeenCalledTimes(1)
+			expect(events.updateTournament.mock.calls[0][1].roundId).toBe(1)
+		})
+	})
+
+	describe("recreated tournaments", () => {
+		it("matches by name when Golf Genius recreated the tournament with a new id", async () => {
+			const existing = {
+				id: 55,
+				name: grossChampionship.name,
+				ggId: "champ-gross-OLD",
+				ggSpecId: null,
+			}
+			const { service, events } = createMocks({
+				existingRounds: [{ id: 1, ggId: "r1" }],
+				rounds: [ggRound1],
+				existingTournaments: [existing],
+				tournamentsByRound: { r1: [grossChampionship] },
+			})
+
+			const summary = await service.syncEvent(10)
+
+			expect(summary.tournamentsCreated).toBe(0)
+			expect(summary.tournamentsUpdated).toBe(1)
+			const [id, data] = events.updateTournament.mock.calls[0]
+			expect(id).toBe(55)
+			expect(data.ggId).toBe("champ-gross-new")
+			expect(data.ggSpecId).toBe("spec-champ")
+		})
+
+		it("matches by spec id when the tournament was recreated AND renamed", async () => {
+			// Real case: "Saturday Master Net Skins - Master Net Skins" was recreated
+			// as "Saturday Master Net Skins - Master Skins" with a new id.
+			const existing = {
+				id: 56,
+				name: "Saturday Senior Gross Skins - OLD FLIGHT NAME",
+				ggId: "skins-sat-OLD",
+				ggSpecId: "spec-skins-sat",
+			}
+			const { service, events } = createMocks({
+				existingRounds: [{ id: 1, ggId: "r1" }],
+				rounds: [ggRound1],
+				existingTournaments: [existing],
+				tournamentsByRound: { r1: [saturdaySkins] },
+			})
+
+			const summary = await service.syncEvent(10)
+
+			expect(summary.tournamentsCreated).toBe(0)
+			expect(summary.tournamentsUpdated).toBe(1)
+			const [id, data] = events.updateTournament.mock.calls[0]
+			expect(id).toBe(56)
+			expect(data.ggId).toBe("skins-sat")
+			expect(data.name).toBe(saturdaySkins.name)
+		})
+
+		it("does not match by spec id when multiple candidates share it (gross/net pair)", async () => {
+			// Gross and net views of a flighted tournament share a spec id. If both
+			// were renamed, a spec-only match would be ambiguous — create instead.
+			const existingGross = {
+				id: 57,
+				name: "Gross Championship - OLD",
+				ggId: "champ-gross-OLD",
+				ggSpecId: "spec-champ",
+			}
+			const existingNet = {
+				id: 58,
+				name: "Net Championship - OLD",
+				ggId: "champ-net-OLD",
+				ggSpecId: "spec-champ",
+			}
+			const { service, events } = createMocks({
+				existingRounds: [{ id: 1, ggId: "r1" }],
+				rounds: [ggRound1],
+				existingTournaments: [existingGross, existingNet],
+				tournamentsByRound: { r1: [grossChampionship, netChampionship] },
+			})
+
+			const summary = await service.syncEvent(10)
+
+			expect(events.updateTournament).not.toHaveBeenCalled()
+			expect(summary.tournamentsCreated).toBe(2)
+			// The stale rows are reported, not deleted
+			expect(summary.warnings).toHaveLength(2)
+		})
+	})
+
+	describe("field derivation", () => {
+		it("derives isNet from the name, not handicap_format, for gross/net pairs", async () => {
+			const { service, events } = createMocks({
+				rounds: [ggRound1],
+				tournamentsByRound: { r1: [grossChampionship, netChampionship] },
+			})
+
+			await service.syncEvent(10)
+
+			const created = events.createTournament.mock.calls.map((c) => c[0])
+			expect(created.find((d) => d.ggId === "champ-gross-new")?.isNet).toBe(0)
+			expect(created.find((d) => d.ggId === "champ-net-new")?.isNet).toBe(1)
+		})
+
+		it("falls back to handicap_format when the name has no gross/net hint", async () => {
+			const proxy = ggTournament({
+				id: "proxy-1",
+				name: "Sat. 3E Proxy",
+				score_format: "user_scored",
+				handicap_format: "gross",
+			})
+			const { service, events } = createMocks({
+				rounds: [ggRound1],
+				tournamentsByRound: { r1: [proxy] },
+			})
+
+			await service.syncEvent(10)
+
+			expect(events.createTournament.mock.calls[0][0].isNet).toBe(0)
+		})
+
+		it("derives points format from the name", async () => {
+			const points = ggTournament({
+				id: "points-1",
+				name: "Senior Gross Points - Senior Division",
+				handicap_format: "gross",
+			})
+			const { service, events } = createMocks({
+				rounds: [ggRound1],
+				tournamentsByRound: { r1: [points] },
+			})
+
+			await service.syncEvent(10)
+
+			expect(events.createTournament.mock.calls[0][0].format).toBe("points")
+		})
+	})
+
+	describe("one-day events (regression)", () => {
+		it("first sync creates every tournament exactly as before", async () => {
+			const skins = saturdaySkins
+			const proxy = ggTournament({
+				id: "proxy-1",
+				name: "Sat. 3E Proxy",
+				score_format: "user_scored",
+				handicap_format: "gross",
+			})
+			const { service, events } = createMocks({
+				rounds: [ggRound1],
+				tournamentsByRound: { r1: [skins, proxy] },
+			})
+
+			const summary = await service.syncEvent(10)
+
+			expect(summary.tournamentsCreated).toBe(2)
+			expect(summary.tournamentsUpdated).toBe(0)
+			expect(summary.errors).toEqual([])
+			expect(summary.warnings).toEqual([])
+			expect(events.createTournament).toHaveBeenCalledTimes(2)
+		})
+
+		it("re-sync updates by ggId exactly as before", async () => {
+			const existing = {
+				id: 60,
+				name: saturdaySkins.name,
+				ggId: "skins-sat",
+				ggSpecId: null,
+			}
+			const { service, events } = createMocks({
+				existingRounds: [{ id: 1, ggId: "r1" }],
+				rounds: [ggRound1],
+				existingTournaments: [existing],
+				tournamentsByRound: { r1: [saturdaySkins] },
+			})
+
+			const summary = await service.syncEvent(10)
+
+			expect(summary.tournamentsUpdated).toBe(1)
+			expect(summary.tournamentsCreated).toBe(0)
+			expect(events.updateTournament.mock.calls[0][0]).toBe(60)
+		})
+	})
+
+	describe("error handling", () => {
+		it("collects per-tournament errors without aborting the sync", async () => {
+			const { service, events } = createMocks({
+				rounds: [ggRound1],
+				tournamentsByRound: { r1: [grossChampionship, saturdaySkins] },
+			})
+			events.createTournament
+				.mockRejectedValueOnce(new Error("ER_DUP_ENTRY"))
+				.mockResolvedValueOnce({ id: 200 })
+
+			const summary = await service.syncEvent(10)
+
+			expect(summary.tournamentsCreated).toBe(1)
+			expect(summary.errors).toHaveLength(1)
+			expect(summary.errors[0]).toContain(grossChampionship.name)
+			expect(summary.errors[0]).toContain("ER_DUP_ENTRY")
+			// The second tournament was still processed
+			expect(events.createTournament).toHaveBeenCalledTimes(2)
+		})
+	})
+})

--- a/apps/api/src/golfgenius/services/__tests__/import-all-results.service.test.ts
+++ b/apps/api/src/golfgenius/services/__tests__/import-all-results.service.test.ts
@@ -1,0 +1,251 @@
+import { ImportAllResultsService } from "../import-all-results.service"
+
+// =============================================================================
+// Test Fixtures
+// =============================================================================
+
+function makeTournament(overrides: Record<string, unknown>) {
+	return {
+		id: 1,
+		eventId: 10,
+		roundId: 1,
+		name: "Saturday Senior Gross Skins",
+		format: "skins",
+		isNet: false,
+		ggId: "t-1",
+		ggSpecId: null,
+		...overrides,
+	}
+}
+
+const mockClubEvent = {
+	id: 10,
+	ggId: "evt-1",
+	eventRounds: [{ id: 1, eventId: 10, roundNumber: 1, roundDate: "2026-08-01", ggId: "r1" }],
+	tournaments: [] as unknown[],
+}
+
+// Aggregate shapes taken from the real two-day championship results payload
+// (Gross Senior Championship, 2026 Senior Club Championship).
+const winnerAggregate = {
+	id: 1,
+	id_str: "agg-1",
+	member_ids: [1],
+	member_ids_str: ["m-1"],
+	member_cards: [
+		{ member_id: 1, member_id_str: "m-1", member_card_id: 11, member_card_id_str: "mc-1" },
+	],
+	position: "1",
+	rank: "1",
+	name: "Todd Fenwick",
+	score: "+4",
+	stableford: null,
+	total: "148",
+	purse: "$120.00",
+	net_scores: [],
+	gross_scores: [],
+}
+
+const unpaidAggregate = {
+	...winnerAggregate,
+	id_str: "agg-2",
+	member_ids_str: ["m-2"],
+	member_cards: [
+		{ member_id: 2, member_id_str: "m-2", member_card_id: 12, member_card_id_str: "mc-2" },
+	],
+	position: "--",
+	rank: "7",
+	name: "Tod Jaeger",
+	total: "159",
+	purse: "",
+}
+
+const withdrawnAggregate = {
+	...winnerAggregate,
+	id_str: "agg-3",
+	member_ids_str: ["m-3"],
+	member_cards: [
+		{ member_id: 3, member_id_str: "m-3", member_card_id: 13, member_card_id_str: "mc-3" },
+	],
+	position: "11",
+	rank: "21",
+	name: "Michael Moriarity",
+	score: "-",
+	total: "WD",
+	purse: "",
+}
+
+// Synthetic: a non-numeric total on a paid row must not produce a NaN score
+const paidNonNumericAggregate = {
+	...withdrawnAggregate,
+	id_str: "agg-4",
+	purse: "$40.00",
+}
+
+// =============================================================================
+// Mock Setup
+// =============================================================================
+
+function createMocks(tournaments: unknown[]) {
+	const apiClient = {
+		getTournamentResults: jest.fn().mockResolvedValue({ id: 1, adjusted: false, scopes: [] }),
+	}
+	let completeResolve: (value: unknown) => void
+	const completed = new Promise((resolve) => (completeResolve = resolve))
+	const progressTracker = {
+		startTournamentTracking: jest.fn().mockReturnValue({ subscribe: jest.fn() }),
+		emitTournamentProgress: jest.fn(),
+		completeOperation: jest.fn().mockImplementation((_eventId, result) => {
+			completeResolve(result)
+			return Promise.resolve()
+		}),
+		errorOperation: jest.fn().mockImplementation((_eventId, _action, message) => {
+			completeResolve({ hardError: message })
+			return Promise.resolve()
+		}),
+	}
+	const eventsService = {
+		getCompleteClubEventById: jest.fn().mockResolvedValue({ ...mockClubEvent, tournaments }),
+		deleteTournamentResults: jest.fn().mockResolvedValue(undefined),
+		insertTournamentResults: jest.fn().mockResolvedValue(undefined),
+	}
+	const registrationService = {
+		getPlayerMapForEvent: jest.fn().mockResolvedValue(
+			new Map([
+				["m-1", { id: 101, firstName: "Todd", lastName: "Fenwick" }],
+				["m-2", { id: 102, firstName: "Tod", lastName: "Jaeger" }],
+				["m-3", { id: 103, firstName: "Michael", lastName: "Moriarity" }],
+			]),
+		),
+	}
+	const service = new ImportAllResultsService(
+		apiClient as any,
+		progressTracker as any,
+		eventsService as any,
+		registrationService as any,
+	)
+	return { service, apiClient, progressTracker, eventsService, completed }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("ImportAllResultsService", () => {
+	describe("importAllResultsStream", () => {
+		it("excludes any tournament with 'overall' in the name (case-insensitive)", async () => {
+			const tournaments = [
+				makeTournament({ id: 1, name: "Overall" }),
+				makeTournament({ id: 2, name: "Saturday Overall", format: "stroke" }),
+				makeTournament({ id: 3, name: "Sunday overall", format: "stroke" }),
+				makeTournament({ id: 4, name: "Saturday Senior Gross Skins" }),
+			]
+			const { service, progressTracker, completed } = createMocks(tournaments)
+
+			await service.importAllResultsStream(10)
+			await completed
+
+			expect(progressTracker.startTournamentTracking).toHaveBeenCalledWith(10, 1)
+		})
+
+		it("continues with remaining tournaments when one cannot be mapped", async () => {
+			const tournaments = [
+				// roundId 99 does not exist on the event -> toTournamentData throws
+				makeTournament({ id: 1, roundId: 99 }),
+				makeTournament({ id: 2 }),
+			]
+			const { service, apiClient, progressTracker, completed } = createMocks(tournaments)
+
+			await service.importAllResultsStream(10)
+			const result = (await completed) as { errors: { itemName: string }[] }
+
+			expect(result.errors).toHaveLength(1)
+			expect(result.errors[0].itemName).toBe("Saturday Senior Gross Skins")
+			// The healthy tournament was still fetched and processed
+			expect(apiClient.getTournamentResults).toHaveBeenCalledTimes(1)
+			expect(progressTracker.completeOperation).toHaveBeenCalled()
+			expect(progressTracker.errorOperation).not.toHaveBeenCalled()
+		})
+
+		it("does not delete existing results when the Golf Genius fetch fails", async () => {
+			const tournaments = [makeTournament({ id: 1 })]
+			const { service, apiClient, eventsService, completed } = createMocks(tournaments)
+			apiClient.getTournamentResults.mockRejectedValue(new Error("404 Not Found"))
+
+			await service.importAllResultsStream(10)
+			const result = (await completed) as { errors: { error: string }[] }
+
+			expect(eventsService.deleteTournamentResults).not.toHaveBeenCalled()
+			expect(result.errors.some((e) => e.error.includes("404"))).toBe(true)
+		})
+
+		it("deletes existing results only after a successful fetch", async () => {
+			const tournaments = [makeTournament({ id: 1 })]
+			const { service, apiClient, eventsService, completed } = createMocks(tournaments)
+
+			await service.importAllResultsStream(10)
+			await completed
+
+			expect(apiClient.getTournamentResults).toHaveBeenCalled()
+			expect(eventsService.deleteTournamentResults).toHaveBeenCalledWith(1)
+			const fetchOrder = apiClient.getTournamentResults.mock.invocationCallOrder[0]
+			const deleteOrder = eventsService.deleteTournamentResults.mock.invocationCallOrder[0]
+			expect(fetchOrder).toBeLessThan(deleteOrder)
+		})
+	})
+
+	describe("stroke results from a two-day tournament", () => {
+		function prepare(service: ImportAllResultsService, aggregate: unknown) {
+			const result = {
+				tournamentId: 1,
+				tournamentName: "",
+				eventName: "",
+				resultsImported: 0,
+				errors: [],
+			}
+			const playerMap = new Map([
+				["m-1", { id: 101 }],
+				["m-2", { id: 102 }],
+				["m-3", { id: 103 }],
+			])
+			return (service as any).prepareStrokePlayerResult(
+				{ id: 1, name: "Gross Senior Championship", format: "stroke" },
+				aggregate,
+				"Flight 1",
+				result,
+				playerMap,
+			)
+		}
+
+		it("imports a paid finisher with the cumulative total", () => {
+			const { service } = createMocks([])
+			const record = prepare(service, winnerAggregate)
+
+			expect(record).not.toBeNull()
+			expect(record.playerId).toBe(101)
+			expect(record.position).toBe(1)
+			expect(record.score).toBe(148)
+			expect(record.amount).toBe("120.00")
+			expect(record.flight).toBe("Flight 1")
+		})
+
+		it("drops unpaid rows (position '--', empty purse)", () => {
+			const { service } = createMocks([])
+			expect(prepare(service, unpaidAggregate)).toBeNull()
+		})
+
+		it("drops withdrawn players (total 'WD', empty purse)", () => {
+			const { service } = createMocks([])
+			expect(prepare(service, withdrawnAggregate)).toBeNull()
+		})
+
+		it("stores a null score, not NaN, for a paid row with a non-numeric total", () => {
+			const { service } = createMocks([])
+			const record = prepare(service, paidNonNumericAggregate)
+
+			expect(record).not.toBeNull()
+			expect(record.score).toBeNull()
+			expect(record.amount).toBe("40.00")
+		})
+	})
+})

--- a/apps/api/src/golfgenius/services/event-sync.service.ts
+++ b/apps/api/src/golfgenius/services/event-sync.service.ts
@@ -10,6 +10,8 @@ interface EventSyncSummary {
 	roundsUpdated: number
 	tournamentsCreated: number
 	tournamentsUpdated: number
+	errors: string[]
+	warnings: string[]
 }
 
 interface CourseSyncSummary {
@@ -39,6 +41,8 @@ export class EventSyncService {
 			roundsUpdated: 0,
 			tournamentsCreated: 0,
 			tournamentsUpdated: 0,
+			errors: [],
+			warnings: [],
 		}
 
 		// 1) Load our event
@@ -98,9 +102,18 @@ export class EventSyncService {
 			}
 		}
 
-		// 5) Upsert tournaments by ggId.
+		// 5) Upsert tournaments.
+		//
+		// Golf Genius quirks this has to survive:
+		// - A multi-round tournament (e.g. a 2-day total) is listed under every round
+		//   with the same tournament id. It must map to ONE local row (first round wins).
+		// - Golf Genius recreates tournaments with a brand-new id when their setup
+		//   changes mid-event (e.g. flighting after round 1), sometimes renaming them.
+		//   The tournament_spec_id survives recreation, so match ggId → name → specId
+		//   and refresh the stored ids on every match.
 		const existingTournaments = await this.events.findTournamentsByEventId(localEventId)
-		const existingTournamentsByGgId = new Map(existingTournaments.map((t) => [t.ggId, t]))
+		const claimedLocalIds = new Set<number>()
+		const seenGgIds = new Set<string>()
 
 		for (const gr of ggRounds) {
 			const localRoundId = ggRoundIdToLocalId[String(gr.id)]
@@ -110,28 +123,86 @@ export class EventSyncService {
 			}
 			const ggTournaments = await this.apiClient.getRoundTournaments(ggEventId, String(gr.id))
 			for (const gt of ggTournaments) {
-				const isNet = gt.handicap_format.toLowerCase().includes("net")
-				const isPoints = gt.name.toLowerCase().includes("points")
+				// A tournament already handled under an earlier round keeps that binding.
+				if (seenGgIds.has(gt.id)) continue
+				seenGgIds.add(gt.id)
+
+				// Gross/net variants of a flighted tournament can both report a "net"
+				// handicap_format, so the name is the more reliable signal.
+				const nameLower = gt.name.toLowerCase()
+				const isNet = nameLower.includes("gross")
+					? false
+					: nameLower.includes("net") || gt.handicap_format.toLowerCase().includes("net")
+				const isPoints = nameLower.includes("points")
 				const data = {
 					name: gt.name,
 					format: isPoints ? "points" : gt.score_format.toLowerCase(),
 					isNet: isNet ? 1 : 0,
 					ggId: gt.id,
+					ggSpecId: gt.tournament_spec_id ?? null,
 					eventId: localEventId,
 					roundId: localRoundId,
 				}
-				const existing = existingTournamentsByGgId.get(gt.id)
-				if (existing) {
-					await this.events.updateTournament(existing.id, data)
-					summary.tournamentsUpdated += 1
-				} else {
-					await this.events.createTournament(data)
-					summary.tournamentsCreated += 1
+
+				const existing = this.findMatchingTournament(gt, existingTournaments, claimedLocalIds)
+				try {
+					if (existing) {
+						claimedLocalIds.add(existing.id)
+						await this.events.updateTournament(existing.id, data)
+						summary.tournamentsUpdated += 1
+					} else {
+						const created = await this.events.createTournament(data)
+						if (created && created.id) claimedLocalIds.add(created.id)
+						summary.tournamentsCreated += 1
+					}
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error)
+					summary.errors.push(`Failed to sync tournament "${gt.name}": ${message}`)
+					this.logger.error(`Failed to sync tournament "${gt.name}"`, message)
 				}
 			}
 		}
 
+		// Local tournaments Golf Genius no longer reports (stale ids from recreated
+		// tournaments). Not deleted automatically because results may hang off them.
+		for (const t of existingTournaments) {
+			if (!claimedLocalIds.has(t.id)) {
+				summary.warnings.push(
+					`Local tournament "${t.name}" (ggId ${t.ggId}) was not found in Golf Genius`,
+				)
+			}
+		}
+
 		return summary
+	}
+
+	/**
+	 * Find the local tournament that corresponds to a Golf Genius tournament.
+	 * Match order: ggId (normal case), then name (recreated with a new id),
+	 * then tournament_spec_id (recreated AND renamed). Rows already claimed
+	 * by another tournament in this sync run are never matched again.
+	 */
+	private findMatchingTournament(
+		gt: { id: string; name: string; tournament_spec_id?: string | null },
+		existingTournaments: { id: number; name: string; ggId: string; ggSpecId: string | null }[],
+		claimedLocalIds: Set<number>,
+	): { id: number; name: string; ggId: string; ggSpecId: string | null } | undefined {
+		const unclaimed = existingTournaments.filter((t) => !claimedLocalIds.has(t.id))
+
+		const byGgId = unclaimed.find((t) => t.ggId === gt.id)
+		if (byGgId) return byGgId
+
+		const byName = unclaimed.find((t) => t.name === gt.name)
+		if (byName) return byName
+
+		// Spec ids are shared by gross/net views of the same tournament, so only
+		// match when exactly one candidate remains.
+		if (gt.tournament_spec_id) {
+			const bySpecId = unclaimed.filter((t) => t.ggSpecId === gt.tournament_spec_id)
+			if (bySpecId.length === 1) return bySpecId[0]
+		}
+
+		return undefined
 	}
 
 	/**

--- a/apps/api/src/golfgenius/services/import-all-results.service.ts
+++ b/apps/api/src/golfgenius/services/import-all-results.service.ts
@@ -51,7 +51,11 @@ export class ImportAllResultsService {
 
 	async importAllResultsStream(eventId: number): Promise<Observable<TournamentProgressEvent>> {
 		const clubEvent = await this.eventsService.getCompleteClubEventById(eventId)
-		const tournaments = clubEvent.tournaments.filter((t) => t.name !== "Overall")
+		// By club convention, "overall" tournaments (e.g. "Overall", "Saturday Overall")
+		// exist for scoring only and never have results/payouts.
+		const tournaments = clubEvent.tournaments.filter(
+			(t) => !t.name.toLowerCase().includes("overall"),
+		)
 
 		if (tournaments.length === 0) {
 			throw new Error(`No tournaments found for event ${eventId}`)
@@ -88,40 +92,57 @@ export class ImportAllResultsService {
 						message: `Processing tournament ${i + 1} of ${totalTournaments}: ${t.name}...`,
 					})
 
-					const tournamentData = toTournamentData(t, clubEvent)
-					const tournamentResult = await this.importTournamentResults(
-						tournamentData,
-						this.selectProcessor(t.format),
-						undefined, // No per-player progress for streaming
-						(success, tournamentName) => {
-							processedTournaments++
-							this.progressTracker.emitTournamentProgress(eventId, {
-								totalTournaments,
-								processedTournaments,
-								status: processedTournaments >= totalTournaments ? "complete" : "processing",
-								message: success
-									? `Processed ${tournamentName} (${processedTournaments}/${totalTournaments})`
-									: `Skipped ${tournamentName} (${processedTournaments}/${totalTournaments})`,
-							})
-						}, // Tournament completion callback
-					)
+					// A bad tournament (e.g. missing round or ggId) should not abort the
+					// import of the remaining tournaments.
+					try {
+						const tournamentData = toTournamentData(t, clubEvent)
+						const tournamentResult = await this.importTournamentResults(
+							tournamentData,
+							this.selectProcessor(t.format),
+							undefined, // No per-player progress for streaming
+							(success, tournamentName) => {
+								processedTournaments++
+								this.progressTracker.emitTournamentProgress(eventId, {
+									totalTournaments,
+									processedTournaments,
+									status: processedTournaments >= totalTournaments ? "complete" : "processing",
+									message: success
+										? `Processed ${tournamentName} (${processedTournaments}/${totalTournaments})`
+										: `Skipped ${tournamentName} (${processedTournaments}/${totalTournaments})`,
+								})
+							}, // Tournament completion callback
+						)
 
-					this.logger.log(
-						`Processed tournamentResult for ${tournamentResult.tournamentName}: ${tournamentResult.resultsImported}`,
-					)
+						this.logger.log(
+							`Processed tournamentResult for ${tournamentResult.tournamentName}: ${tournamentResult.resultsImported}`,
+						)
 
-					// Aggregate results
-					result.created += tournamentResult.resultsImported
-					result.totalProcessed += tournamentResult.resultsImported
+						// Aggregate results
+						result.created += tournamentResult.resultsImported
+						result.totalProcessed += tournamentResult.resultsImported
 
-					// Convert errors to ImportError format
-					result.errors.push(
-						...tournamentResult.errors.map((error: string) => ({
+						// Convert errors to ImportError format
+						result.errors.push(
+							...tournamentResult.errors.map((error: string) => ({
+								itemId: t.id?.toString() ?? "",
+								itemName: t.name,
+								error,
+							})),
+						)
+					} catch (error) {
+						processedTournaments++
+						result.errors.push({
 							itemId: t.id?.toString() ?? "",
 							itemName: t.name,
-							error,
-						})),
-					)
+							error: error instanceof Error ? error.message : String(error),
+						})
+						this.progressTracker.emitTournamentProgress(eventId, {
+							totalTournaments,
+							processedTournaments,
+							status: processedTournaments >= totalTournaments ? "complete" : "processing",
+							message: `Skipped ${t.name} (${processedTournaments}/${totalTournaments})`,
+						})
+					}
 				}
 
 				// Complete the operation
@@ -199,14 +220,15 @@ export class ImportAllResultsService {
 			// Fetch player map for this event (optimization: single query instead of N+1)
 			const playerMap = await this.fetchPlayerMapForEvent(tournamentData.eventId)
 
-			// Delete existing results (idempotent)
-			await this.eventsService.deleteTournamentResults(tournamentData.id)
-
-			// Fetch results from Golf Genius
+			// Fetch results from Golf Genius BEFORE deleting existing results, so a
+			// failed fetch (e.g. stale tournament id) leaves prior results intact.
 			const ggResults = await this.fetchGGResults(tournamentData, result)
 			if (!ggResults) {
 				return result
 			}
+
+			// Delete existing results (idempotent)
+			await this.eventsService.deleteTournamentResults(tournamentData.id)
 
 			// Process results using the provided processor
 			await processor(tournamentData, result, ggResults, playerMap, onPlayerProcessed)
@@ -615,13 +637,12 @@ export class ImportAllResultsService {
 		// Parse position from aggregate.position (handles "T4" tie format)
 		const position = parsePosition(playerData.position)
 
-		// Parse score (total strokes)
+		// Parse score (total strokes); non-numeric totals like "WD" become null
 		const totalStr = playerData.total
 		let score: number | null = null
-		try {
-			score = totalStr && totalStr.trim() !== "" ? parseInt(totalStr, 10) : null
-		} catch {
-			score = null
+		if (totalStr && totalStr.trim() !== "") {
+			const parsed = parseInt(totalStr, 10)
+			score = isNaN(parsed) ? null : parsed
 		}
 
 		// Parse purse amount
@@ -676,13 +697,13 @@ export class ImportAllResultsService {
 		// Parse position from aggregate.position (handles "T4" tie format)
 		const position = parsePosition(playerData.position)
 
-		// Parse score from aggregate.total (the quota result like +2, -1)
+		// Parse score from aggregate.total (the quota result like +2, -1);
+		// non-numeric totals like "WD" become null
 		const totalStr = playerData.total
 		let score: number | null = null
-		try {
-			score = totalStr && totalStr.trim() !== "" ? parseInt(totalStr, 10) : null
-		} catch {
-			score = null
+		if (totalStr && totalStr.trim() !== "") {
+			const parsed = parseInt(totalStr, 10)
+			score = isNaN(parsed) ? null : parsed
 		}
 
 		// Parse summary from aggregate.score formatted as "Quota score: [value]"
@@ -776,13 +797,12 @@ export class ImportAllResultsService {
 		// Parse quota-style fields from aggregate (shared by all team members)
 		const position = parsePosition(aggregate.position)
 
-		// Parse score from aggregate.total (the quota result like +2, -1)
+		// Parse score from aggregate.total (the quota result like +2, -1);
+		// non-numeric totals like "WD" become null
 		let score: number | null = null
-		try {
-			score =
-				aggregate.total && aggregate.total.trim() !== "" ? parseInt(aggregate.total, 10) : null
-		} catch {
-			score = null
+		if (aggregate.total && aggregate.total.trim() !== "") {
+			const parsed = parseInt(aggregate.total, 10)
+			score = isNaN(parsed) ? null : parsed
 		}
 
 		// Parse summary from aggregate.stableford or aggregate.score
@@ -898,14 +918,16 @@ export class ImportAllResultsService {
 				continue
 			}
 
-			// Parse team score (aggregate total) - each player gets the team score
+			// Parse team score (aggregate total) - each player gets the team score;
+			// non-numeric totals like "WD" become null
 			let score: number | null = null
-			try {
-				score =
-					aggregate.total && aggregate.total.trim() !== "" ? parseInt(aggregate.total, 10) : null
-			} catch {
-				this.logger.warn(`Failed to parse team total score for ${teamName}: ${aggregate.total}`)
-				score = null
+			if (aggregate.total && aggregate.total.trim() !== "") {
+				const parsed = parseInt(aggregate.total, 10)
+				if (isNaN(parsed)) {
+					this.logger.warn(`Failed to parse team total score for ${teamName}: ${aggregate.total}`)
+				} else {
+					score = parsed
+				}
 			}
 
 			// Prepare record


### PR DESCRIPTION
## Summary

Steps 2–3 of the two-day tournament fix (follows #106, which added `gg_spec_id`). Fixes the two bugs from the Senior Club Championship weekend: sync always reporting failure, and results failing to import.

## Root causes addressed

1. **Cross-round duplicates**: Golf Genius lists a multi-round tournament (Championship, Points) under *every* round with the same id. The sync's create branch hit `unique_event_tournamentname` and the whole sync threw → admin always showed failure.
2. **Recreated tournaments**: Golf Genius issues a brand-new tournament id when setup changes mid-event (e.g. flighting Sunday morning), sometimes renaming the tournament too. Stored ids went stale, so results fetches hit dead ids.

## Changes

**EventSyncService**
- Cross-round tournaments map to one local row, bound to their first round; later rounds are skipped
- Existing rows matched by ggId → name → `tournament_spec_id` (spec match only when unambiguous — gross/net pairs share a spec id); ids and names refreshed on every match
- `isNet` derived from the tournament name before `handicap_format` (recreated gross/net pairs can both report `usga_net`)
- Per-tournament failures collected into `summary.errors` instead of aborting; local tournaments no longer present in Golf Genius reported in `summary.warnings` (never auto-deleted)

**ImportAllResultsService**
- Tournaments with "overall" anywhere in the name are excluded (club convention: overall tournaments never carry results) — previously only an exact `"Overall"` match
- Results are fetched from Golf Genius *before* existing rows are deleted, so a failed fetch can no longer wipe previously imported results
- A tournament that fails to map (`toTournamentData`) no longer aborts the remaining imports
- Non-numeric totals (`"WD"`) become a null score instead of NaN, which would have poisoned the batch insert

## Behavior change to note

Sync now logs `isSuccessful: 1` with an error list when individual tournaments fail, rather than hard-failing the run — matching how Import Results already reports. The admin card still shows the error count.

## Testing

19 new tests (fixtures modeled on the real Senior Club Championship payloads): cross-round dedupe, recreation via name and spec-id matching, gross/net spec ambiguity, one-day regression paths, per-tournament error isolation, the overall filter, fetch-before-delete ordering, and WD/"--" row handling. Full api suite: 26 suites, 562 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)